### PR TITLE
A0-3152: Add view methods.

### DIFF
--- a/farm/contracts/lib.rs
+++ b/farm/contracts/lib.rs
@@ -371,12 +371,10 @@ mod farm {
 
             let state = self.get_state().ok()?;
             let shares = state.shares.get(account)?;
-            let claimed_rewards = state.claimed_rewards(account).ok()?;
 
             Some(UserPositionView {
                 shares,
                 unclaimed_rewards,
-                claimed_rewards,
             })
         }
 
@@ -561,24 +559,6 @@ mod farm {
                         .unwrap_or(0)
                 })
                 .collect()
-        }
-
-        pub fn claimed_rewards(&self, account: AccountId) -> Result<Vec<u128>, FarmError> {
-            let shares = self.shares.get(account).ok_or(FarmError::CallerNotFarmer)?;
-
-            let rewards_per_token_paid_so_far = match self.user_reward_per_token_paid.get(account) {
-                Some(rrtps) => rrtps,
-                // No rewards paid so far.
-                None => return Ok(vec![0; self.reward_tokens_info.len()]),
-            };
-
-            let mut claimed_rewards = vec![];
-
-            for claimed_rr in rewards_per_token_paid_so_far {
-                claimed_rewards.push(rewards_earned(shares, claimed_rr.0, U256::zero())?);
-            }
-
-            Ok(claimed_rewards)
         }
     }
 

--- a/farm/contracts/views.rs
+++ b/farm/contracts/views.rs
@@ -57,6 +57,4 @@ pub struct UserPositionView {
     pub shares: u128,
     // Amount of unclaimed rewards.
     pub unclaimed_rewards: Vec<u128>,
-    // Amount of already-claimed rewards.
-    pub claimed_rewards: Vec<u128>,
 }


### PR DESCRIPTION
This PR adds two new methods to the farm contract that return information about user-specific position or farm in general.

These methods are:
1. `view_farm_details` which returns `FarmDetailsView`
2. `view_user_position(account: AccountId)` which returns `UserPositionView`.

```
FarmDetailsView {
    // Address of the pool this farm is for.
    pub pair: AccountId,
    /// Timestamp (in milliseconds) of the farm start.
    pub start: u64,
    /// Timestamp (in milliseconds) of the farm end.
    pub end: u64,
    /// Amount of LP tokens locked in the farm.
    pub total_shares: u128,
    /// Reward tokens info.
    pub reward_tokens: Vec<RewardTokenInfoView>,
}

RewardTokenInfoView {
    // Address of the reward token.
    token_id: AccountId,
    // Amount of reward tokens per second.
    reward_rate: u128,
}
```
and
```
UserPositionView {
    // Amount of LP tokens locked in the farm by the user.
    pub shares: u128,
    // Amount of unclaimed rewards.
    pub unclaimed_rewards: Vec<u128>,
}
```