### PR TITLE
Split up code for readability

### DIFF
--- a/farm/contracts/instance/lib.rs
+++ b/farm/contracts/instance/lib.rs
@@ -1,28 +1,37 @@
 #![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 pub mod error;
-mod views;
-
+mod math;
+mod reward_token;
+mod state;
 #[cfg(test)]
 mod tests;
-
-// TODO:
-// Add upper bound on farm length.
-// Tests.
-// ? Refactor to make staking logic reusable in different contracts.
+mod utils;
+mod views;
 
 pub use farm::FarmRef;
 
+use ink::env::Environment;
+
+pub type TokenId = <ink::env::DefaultEnvironment as Environment>::AccountId;
+pub type UserId = <ink::env::DefaultEnvironment as Environment>::AccountId;
+pub type Timestamp = <ink::env::DefaultEnvironment as ink::env::Environment>::Timestamp;
+
 #[ink::contract]
 mod farm {
-    use crate::error::FarmError;
-
-    use crate::views::{
-        FarmDetailsView,
-        UserPositionView,
+    use crate::{
+        error::FarmError,
+        reward_token::RewardTokenInfo,
+        state::State,
+        utils::{
+            safe_balance_of,
+            safe_transfer,
+        },
+        views::{
+            FarmDetailsView,
+            UserPositionView,
+        },
     };
-
-    use crate::calculate_rewards_earned;
 
     use psp22_traits::PSP22;
 
@@ -142,7 +151,8 @@ mod farm {
                     to_refund.push((token_ref, 0));
                     continue
                 }
-                let balance: Balance = safe_balance_of(&token_ref, self.env().account_id());
+                let balance: Balance =
+                    safe_balance_of::<Environment>(&token_ref, self.env().account_id());
                 let refund_amount = balance.saturating_sub(reserved_for_rewards);
                 reward_token.unclaimed_rewards_total = 0;
                 to_refund.push((token_ref, refund_amount));
@@ -174,7 +184,8 @@ mod farm {
         pub fn deposit_all(&mut self) -> Result<(), FarmError> {
             self.ensure_running(true)?;
             self.update_reward_index()?;
-            let token_balance = safe_balance_of(&self.pool.into(), self.env().caller());
+            let token_balance =
+                safe_balance_of::<Environment>(&self.pool.into(), self.env().caller());
             Self::ensure_non_zero_amount(token_balance)?;
             self.add_shares(token_balance)
         }
@@ -461,323 +472,4 @@ mod farm {
                 .expect("to properly deserialize code hash")
         }
     }
-
-    type TokenId = AccountId;
-    type UserId = AccountId;
-
-    use scale::{
-        Decode,
-        Encode,
-    };
-
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
-    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
-    pub struct RewardTokenInfo {
-        /// Tokens deposited as rewards for providing LP to the farm.
-        pub token_id: TokenId,
-        /// How many rewards to pay out for the smallest unit of time.
-        pub reward_rate: u128,
-        /// Totals of unclaimed rewards.
-        // Necessary for not letting owner, re-claim more than allowed to once the farm is stopped.
-        pub unclaimed_rewards_total: u128,
-        /// Reward counter at the last farm change.
-        pub cumulative_reward_per_share: WrappedU256,
-    }
-
-    #[ink::storage_item]
-    pub struct State {
-        /// Creator(owner) of the farm.
-        pub owner: UserId,
-        /// The timestamp when the farm was created.
-        pub start: Timestamp,
-        /// The timestamp when the farm will stop.
-        pub end: Timestamp,
-        /// Reward tokens.
-        pub reward_tokens_info: Vec<RewardTokenInfo>,
-        /// Timestamp of the last farm change.
-        pub timestamp_at_last_update: Timestamp,
-        /// Reward per token paid to the user for each reward token.
-        // We need to track this separately for each reward token as each can have different reward rate.
-        // Vectors should be relatively small (probably < 5).
-        pub user_reward_per_share_paid: Mapping<UserId, Vec<WrappedU256>>,
-        /// Rewards that have not been claimed (withdrawn) by the user yet.
-        pub user_claimable_rewards: Mapping<UserId, Vec<u128>>,
-    }
-
-    impl State {
-        /// Updates the rewards that should be paid out to liquidity providers since the last update.
-        /// Returns an error if there was an issue calculating the rewards.
-        pub fn update_rewards(
-            &mut self,
-            total_shares: u128,
-            current_timestamp: Timestamp,
-        ) -> Result<(), FarmError> {
-            let past = core::cmp::max(self.timestamp_at_last_update, self.start) as u128;
-            let now = core::cmp::min(current_timestamp, self.end) as u128;
-            if past >= now || self.timestamp_at_last_update == current_timestamp {
-                return Ok(())
-            }
-
-            for reward_token in self.reward_tokens_info.iter_mut() {
-                let reward_rate = reward_token.reward_rate;
-                let reward_delta = crate::rewards_per_share_in_time_interval(
-                    reward_rate,
-                    total_shares,
-                    past,
-                    now,
-                )?;
-                let new_cumulative_reward_rate =
-                    reward_token.cumulative_reward_per_share.0 + reward_delta;
-                reward_token.cumulative_reward_per_share = new_cumulative_reward_rate.into();
-                reward_token.unclaimed_rewards_total +=
-                    crate::rewards_earned_by_shares(total_shares, reward_delta)?;
-            }
-
-            self.timestamp_at_last_update = current_timestamp;
-
-            Ok(())
-        }
-
-        /// Computes how much rewards have been earned by the user since the last update
-        /// and updates the user's unclaimed rewards.
-        pub fn move_unclaimed_rewards_to_claimable(
-            &mut self,
-            user_shares: u128,
-            account: AccountId,
-        ) -> Result<Vec<u128>, FarmError> {
-            if user_shares == 0 {
-                return Ok(vec![0; self.reward_tokens_info.len()])
-            }
-
-            let mut reward_per_share_paid_so_far = self
-                .user_reward_per_share_paid
-                .get(account)
-                .unwrap_or(vec![WrappedU256::ZERO; self.reward_tokens_info.len()]);
-
-            let mut uncollected_user_rewards = self
-                .user_claimable_rewards
-                .get(account)
-                .unwrap_or(vec![0; self.reward_tokens_info.len()]);
-
-            let mut new_rewards = vec![0u128; self.reward_tokens_info.len()];
-
-            for (idx, token) in self.reward_tokens_info.iter().enumerate() {
-                new_rewards[idx] = calculate_rewards_earned(
-                    user_shares,
-                    token.cumulative_reward_per_share.0,
-                    reward_per_share_paid_so_far[idx].0,
-                )?;
-                uncollected_user_rewards[idx] =
-                    uncollected_user_rewards[idx].saturating_add(new_rewards[idx]);
-                reward_per_share_paid_so_far[idx] = token.cumulative_reward_per_share;
-            }
-
-            self.user_claimable_rewards
-                .insert(account, &uncollected_user_rewards);
-            self.user_reward_per_share_paid
-                .insert(account, &reward_per_share_paid_so_far);
-
-            Ok(new_rewards)
-        }
-
-        /// Returns the unclaimed rewards for the specified account.
-        pub fn unclaimed_rewards(&self, account: AccountId) -> Result<Vec<u128>, FarmError> {
-            self.user_claimable_rewards
-                .get(account)
-                .ok_or(FarmError::CallerNotFarmer)
-        }
-
-        /// Returns rewards distributable to all farmers for the period between now (or farm end)
-        /// and last farm change.
-        pub fn rewards_distributable(&self, current_timestamp: Timestamp) -> Vec<u128> {
-            let last_time_reward_applicable = core::cmp::min(current_timestamp, self.end) as u128;
-            self.reward_tokens_info
-                .iter()
-                .map(|info| {
-                    info.reward_rate
-                        .checked_mul(
-                            last_time_reward_applicable - self.timestamp_at_last_update as u128,
-                        )
-                        .unwrap_or(0)
-                })
-                .collect()
-        }
-    }
-
-    use ink::codegen::TraitCallBuilder;
-
-    // We're making a concious choice here that we don't want to fail the whole transaction
-    // if a PSP22::transfer fails with a panic.
-    // This is to ensure that funds are not locked in the farm if someone uses malicious
-    // PSP22 token impl for rewards.
-    pub fn safe_transfer(
-        psp22: &mut contract_ref!(PSP22),
-        recipient: AccountId,
-        amount: u128,
-    ) -> Result<(), psp22_traits::PSP22Error> {
-        match psp22
-            .call_mut()
-            .transfer(recipient, amount, vec![])
-            .try_invoke()
-        {
-            Err(ink_env_err) => {
-                ink::env::debug_println!("ink env error: {:?}", ink_env_err);
-                Ok(())
-            }
-            Ok(Err(ink_lang_err)) => {
-                ink::env::debug_println!("ink lang error: {:?}", ink_lang_err);
-                Ok(())
-            }
-            Ok(Ok(Err(psp22_error))) => {
-                ink::env::debug_println!("psp22 error: {:?}", psp22_error);
-                Ok(())
-            }
-            Ok(Ok(Ok(res))) => Ok(res),
-        }
-    }
-
-    // We don't want to fail the whole transaction if PSP22::balance_of fails with a panic either.
-    // We choose to use `0` to denote the "panic" scenarios b/c it's a noop for the farm.
-    pub fn safe_balance_of(psp22: &contract_ref!(PSP22), account: AccountId) -> u128 {
-        match psp22.call().balance_of(account).try_invoke() {
-            Err(ink_env_err) => {
-                ink::env::debug_println!("ink env error: {:?}", ink_env_err);
-                0
-            }
-            Ok(Err(ink_lang_err)) => {
-                ink::env::debug_println!("ink lang error: {:?}", ink_lang_err);
-                0
-            }
-            Ok(Ok(res)) => res,
-        }
-    }
-}
-
-use amm_helpers::math::{
-    casted_mul,
-    MathError,
-};
-use farm::SCALING_FACTOR;
-use primitive_types::U256;
-
-/// Returns rewards due for providing liquidity from `last_update_time` to `last_time_reward_applicable`.
-///
-/// r_j = r_j0 + R/T(t_j - t_j0)
-///
-/// where:
-/// - r_j0 - reward per token stored at the last time any user interacted with the farm
-/// - R - reward rate (rewards distributed per unit of time)
-/// - T - total shares in the farm
-/// - t_j - last time user interacted with the farm, usually _now_.
-/// - t_j0 - last time user "claimed" rewards.
-/// - r_j - rewards due to user for providing liquidity from t_j0 to t_j
-///
-/// See https://github.com/stakewithus/notes/blob/main/excalidraw/staking-rewards.png for more.
-pub fn reward_per_share(
-    cumulative_reward_per_share: U256,
-    reward_rate: u128,
-    total_shares: u128,
-    last_update_time: u128,
-    last_time_reward_applicable: u128,
-) -> Result<U256, MathError> {
-    if total_shares == 0 {
-        return Ok(cumulative_reward_per_share)
-    }
-
-    rewards_per_share_in_time_interval(
-        reward_rate,
-        total_shares,
-        last_update_time,
-        last_time_reward_applicable,
-    )?
-    .checked_add(cumulative_reward_per_share)
-    .ok_or(MathError::Overflow)
-}
-
-/// Calculates the reward per share in a given time interval.
-///
-/// # Arguments
-///
-/// * `reward_rate` - The rate at which rewards are distributed.
-/// * `total_shares` - The total number of shares.
-/// * `from_timestamp` - The starting timestamp of the interval.
-/// * `to_timestamp` - The ending timestamp of the interval.
-///
-/// # Errors
-///
-/// Returns a `MathError::Overflow` if the multiplication overflows, or a `MathError::DivByZero`
-/// if `total_shares` is zero.
-///
-/// # Returns
-///
-/// Returns the reward per share as a `U256` value.
-pub fn rewards_per_share_in_time_interval(
-    reward_rate: u128,
-    total_shares: u128,
-    from_timestamp: u128,
-    to_timestamp: u128,
-) -> Result<U256, MathError> {
-    if total_shares == 0 || from_timestamp > to_timestamp {
-        return Ok(0.into())
-    }
-
-    casted_mul(reward_rate, to_timestamp - from_timestamp)
-        .checked_mul(U256::from(SCALING_FACTOR))
-        .ok_or(MathError::Overflow)?
-        .checked_div(U256::from(total_shares))
-        .ok_or(MathError::DivByZero)
-}
-
-/// Returns rewards earned by the user given `rewards_per_share` for some period of time.
-/// Calculates the rewards earned based on the number of shares, rewards per share, and paid reward per share.
-///
-/// # Arguments
-///
-/// * `shares` - The number of shares.
-/// * `rewards_per_share` - The rewards per share.
-/// * `paid_reward_per_share` - The paid reward per share.
-///
-/// # Errors
-///
-/// Returns a `MathError::Underflow` if the subtraction of `paid_reward_per_share` from `rewards_per_share` results in an underflow.
-///
-/// # Returns
-///
-/// The rewards earned as a `u128` value.
-pub fn calculate_rewards_earned(
-    shares: u128,
-    rewards_per_share: U256,
-    paid_reward_per_share: U256,
-) -> Result<u128, MathError> {
-    let r = rewards_per_share
-        .checked_sub(paid_reward_per_share)
-        .ok_or(MathError::Underflow)?;
-
-    rewards_earned_by_shares(shares, r)
-}
-
-/// Calculates the amount of rewards earned by a given number of shares, based on the rewards per share.
-///
-/// # Arguments
-///
-/// * `shares` - The number of shares for which to calculate the rewards earned.
-/// * `rewards_per_share` - The rewards per share value used to calculate the rewards earned.
-///
-/// # Errors
-///
-/// Returns a `MathError::Overflow` if the multiplication of `rewards_per_share` and `shares` overflows.
-/// Returns a `MathError::DivByZero` if the division of the multiplication result by the scaling factor overflows.
-/// Returns a `MathError::CastOverflow` if the result of the division cannot be cast to `u128`.
-///
-/// # Returns
-///
-/// The amount of rewards earned by the given number of shares, as a `u128`.
-pub fn rewards_earned_by_shares(shares: u128, rewards_per_share: U256) -> Result<u128, MathError> {
-    rewards_per_share
-        .checked_mul(U256::from(shares))
-        .ok_or(MathError::Overflow)?
-        .checked_div(U256::from(SCALING_FACTOR))
-        .ok_or(MathError::DivByZero)?
-        .try_into()
-        .map_err(|_| MathError::CastOverflow)
 }

--- a/farm/contracts/instance/math.rs
+++ b/farm/contracts/instance/math.rs
@@ -1,0 +1,107 @@
+use crate::farm::SCALING_FACTOR;
+use amm_helpers::math::{
+    casted_mul,
+    MathError,
+};
+use primitive_types::U256;
+
+/// Calculates the reward per share in a given time interval.
+///
+/// Covers the `R/T(t_j - t_j0)` in the formula below.
+///
+/// r_j = r_j0 + R/T(t_j - t_j0)
+///
+/// where:
+/// - R - reward rate (rewards distributed per unit of time)
+/// - T - total shares in the farm
+/// - t_j - last time user interacted with the farm, usually _now_.
+/// - t_j0 - last time user "claimed" rewards.
+/// - r_j - rewards due to user for providing liquidity from t_j0 to t_j
+///
+/// See https://github.com/stakewithus/notes/blob/main/excalidraw/staking-rewards.png for more.
+///
+/// # Arguments
+///
+/// * `reward_rate` - The rate at which rewards are distributed.
+/// * `total_shares` - The total number of shares.
+/// * `from_timestamp` - The starting timestamp of the interval.
+/// * `to_timestamp` - The ending timestamp of the interval.
+///
+/// # Errors
+///
+/// Returns a `MathError::Overflow` if the multiplication overflows, or a `MathError::DivByZero`
+/// if `total_shares` is zero.
+///
+/// # Returns
+///
+/// Returns the reward per share as a `U256` value.
+pub fn rewards_per_share_in_time_interval(
+    reward_rate: u128,
+    total_shares: u128,
+    from_timestamp: u128,
+    to_timestamp: u128,
+) -> Result<U256, MathError> {
+    if total_shares == 0 || from_timestamp > to_timestamp {
+        return Ok(0.into())
+    }
+
+    casted_mul(reward_rate, to_timestamp - from_timestamp)
+        .checked_mul(U256::from(SCALING_FACTOR))
+        .ok_or(MathError::Overflow)?
+        .checked_div(U256::from(total_shares))
+        .ok_or(MathError::DivByZero)
+}
+
+/// Returns rewards earned by the user given `rewards_per_share` for some period of time.
+/// Calculates the rewards earned based on the number of shares, rewards per share, and paid reward per share.
+///
+/// # Arguments
+///
+/// * `shares` - The number of shares.
+/// * `rewards_per_share` - The rewards per share.
+/// * `paid_reward_per_share` - The paid reward per share.
+///
+/// # Errors
+///
+/// Returns a `MathError::Underflow` if the subtraction of `paid_reward_per_share` from `rewards_per_share` results in an underflow.
+///
+/// # Returns
+///
+/// The rewards earned as a `u128` value.
+pub fn calculate_rewards_earned(
+    shares: u128,
+    rewards_per_share: U256,
+    paid_reward_per_share: U256,
+) -> Result<u128, MathError> {
+    let r = rewards_per_share
+        .checked_sub(paid_reward_per_share)
+        .ok_or(MathError::Underflow)?;
+
+    rewards_earned_by_shares(shares, r)
+}
+
+/// Calculates the amount of rewards earned by a given number of shares, based on the rewards per share.
+///
+/// # Arguments
+///
+/// * `shares` - The number of shares for which to calculate the rewards earned.
+/// * `rewards_per_share` - The rewards per share value used to calculate the rewards earned.
+///
+/// # Errors
+///
+/// Returns a `MathError::Overflow` if the multiplication of `rewards_per_share` and `shares` overflows.
+/// Returns a `MathError::DivByZero` if the division of the multiplication result by the scaling factor overflows.
+/// Returns a `MathError::CastOverflow` if the result of the division cannot be cast to `u128`.
+///
+/// # Returns
+///
+/// The amount of rewards earned by the given number of shares, as a `u128`.
+pub fn rewards_earned_by_shares(shares: u128, rewards_per_share: U256) -> Result<u128, MathError> {
+    rewards_per_share
+        .checked_mul(U256::from(shares))
+        .ok_or(MathError::Overflow)?
+        .checked_div(U256::from(SCALING_FACTOR))
+        .ok_or(MathError::DivByZero)?
+        .try_into()
+        .map_err(|_| MathError::CastOverflow)
+}

--- a/farm/contracts/instance/reward_token.rs
+++ b/farm/contracts/instance/reward_token.rs
@@ -1,0 +1,21 @@
+use scale::{
+    Decode,
+    Encode,
+};
+
+use crate::TokenId;
+use amm_helpers::types::WrappedU256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Encode, Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct RewardTokenInfo {
+    /// Tokens deposited as rewards for providing LP to the farm.
+    pub token_id: TokenId,
+    /// How many rewards to pay out for the smallest unit of time.
+    pub reward_rate: u128,
+    /// Totals of unclaimed rewards.
+    // Necessary for not letting owner, re-claim more than allowed to once the farm is stopped.
+    pub unclaimed_rewards_total: u128,
+    /// Reward counter at the last farm change.
+    pub cumulative_reward_per_share: WrappedU256,
+}

--- a/farm/contracts/instance/state.rs
+++ b/farm/contracts/instance/state.rs
@@ -1,0 +1,131 @@
+use crate::{
+    error::FarmError,
+    math::*,
+    reward_token::RewardTokenInfo,
+    Timestamp,
+    UserId,
+};
+use amm_helpers::types::WrappedU256;
+use ink::{
+    prelude::{
+        vec,
+        vec::Vec,
+    },
+    storage::Mapping,
+};
+
+#[ink::storage_item]
+pub struct State {
+    /// Creator(owner) of the farm.
+    pub owner: UserId,
+    /// The timestamp when the farm was created.
+    pub start: Timestamp,
+    /// The timestamp when the farm will stop.
+    pub end: Timestamp,
+    /// Reward tokens.
+    pub reward_tokens_info: Vec<RewardTokenInfo>,
+    /// Timestamp of the last farm change.
+    pub timestamp_at_last_update: Timestamp,
+    /// Reward per token paid to the user for each reward token.
+    // We need to track this separately for each reward token as each can have different reward rate.
+    // Vectors should be relatively small (probably < 5).
+    pub user_reward_per_share_paid: Mapping<UserId, Vec<WrappedU256>>,
+    /// Rewards that have not been claimed (withdrawn) by the user yet.
+    pub user_claimable_rewards: Mapping<UserId, Vec<u128>>,
+}
+
+impl State {
+    /// Updates the rewards that should be paid out to liquidity providers since the last update.
+    /// Returns an error if there was an issue calculating the rewards.
+    pub fn update_rewards(
+        &mut self,
+        total_shares: u128,
+        current_timestamp: Timestamp,
+    ) -> Result<(), FarmError> {
+        let past = core::cmp::max(self.timestamp_at_last_update, self.start) as u128;
+        let now = core::cmp::min(current_timestamp, self.end) as u128;
+        if past >= now || self.timestamp_at_last_update == current_timestamp {
+            return Ok(())
+        }
+
+        for reward_token in self.reward_tokens_info.iter_mut() {
+            let reward_rate = reward_token.reward_rate;
+            let reward_delta =
+                rewards_per_share_in_time_interval(reward_rate, total_shares, past, now)?;
+            let new_cumulative_reward_rate =
+                reward_token.cumulative_reward_per_share.0 + reward_delta;
+            reward_token.cumulative_reward_per_share = new_cumulative_reward_rate.into();
+            reward_token.unclaimed_rewards_total +=
+                rewards_earned_by_shares(total_shares, reward_delta)?;
+        }
+
+        self.timestamp_at_last_update = current_timestamp;
+
+        Ok(())
+    }
+
+    /// Computes how much rewards have been earned by the user since the last update
+    /// and updates the user's unclaimed rewards.
+    pub fn move_unclaimed_rewards_to_claimable(
+        &mut self,
+        user_shares: u128,
+        account: UserId,
+    ) -> Result<Vec<u128>, FarmError> {
+        if user_shares == 0 {
+            return Ok(vec![0; self.reward_tokens_info.len()])
+        }
+
+        let mut reward_per_share_paid_so_far = self
+            .user_reward_per_share_paid
+            .get(account)
+            .unwrap_or(vec![WrappedU256::ZERO; self.reward_tokens_info.len()]);
+
+        let mut uncollected_user_rewards = self
+            .user_claimable_rewards
+            .get(account)
+            .unwrap_or(vec![0; self.reward_tokens_info.len()]);
+
+        let mut new_rewards = vec![0u128; self.reward_tokens_info.len()];
+
+        for (idx, token) in self.reward_tokens_info.iter().enumerate() {
+            new_rewards[idx] = calculate_rewards_earned(
+                user_shares,
+                token.cumulative_reward_per_share.0,
+                reward_per_share_paid_so_far[idx].0,
+            )?;
+            uncollected_user_rewards[idx] =
+                uncollected_user_rewards[idx].saturating_add(new_rewards[idx]);
+            reward_per_share_paid_so_far[idx] = token.cumulative_reward_per_share;
+        }
+
+        self.user_claimable_rewards
+            .insert(account, &uncollected_user_rewards);
+        self.user_reward_per_share_paid
+            .insert(account, &reward_per_share_paid_so_far);
+
+        Ok(new_rewards)
+    }
+
+    /// Returns the unclaimed rewards for the specified account.
+    pub fn unclaimed_rewards(&self, account: UserId) -> Result<Vec<u128>, FarmError> {
+        self.user_claimable_rewards
+            .get(account)
+            .ok_or(FarmError::CallerNotFarmer)
+    }
+
+    /// Returns rewards distributable to all farmers for the period between now (or farm end)
+    /// and last farm change.
+    pub fn rewards_distributable(&self, current_timestamp: Timestamp) -> Vec<u128> {
+        let last_time_reward_applicable = core::cmp::min(current_timestamp, self.end) as u128;
+        self.reward_tokens_info
+            .iter()
+            .map(|info| {
+                info.reward_rate
+                    .checked_mul(
+                        last_time_reward_applicable - self.timestamp_at_last_update as u128,
+                    )
+                    .unwrap_or(0)
+            })
+            .collect()
+    }
+}

--- a/farm/contracts/instance/utils.rs
+++ b/farm/contracts/instance/utils.rs
@@ -1,0 +1,57 @@
+use ink::{
+    codegen::TraitCallBuilder,
+    contract_ref,
+    prelude::vec,
+};
+use psp22_traits::PSP22;
+
+use crate::UserId;
+
+// We're making a concious choice here that we don't want to fail the whole transaction
+// if a PSP22::transfer fails with a panic.
+// This is to ensure that funds are not locked in the farm if someone uses malicious
+// PSP22 token impl for rewards.
+pub fn safe_transfer<Env: ink::env::Environment>(
+    psp22: &mut contract_ref!(PSP22, Env),
+    recipient: UserId,
+    amount: u128,
+) -> Result<(), psp22_traits::PSP22Error> {
+    match psp22
+        .call_mut()
+        .transfer(recipient, amount, vec![])
+        .try_invoke()
+    {
+        Err(ink_env_err) => {
+            ink::env::debug_println!("ink env error: {:?}", ink_env_err);
+            Ok(())
+        }
+        Ok(Err(ink_lang_err)) => {
+            ink::env::debug_println!("ink lang error: {:?}", ink_lang_err);
+            Ok(())
+        }
+        Ok(Ok(Err(psp22_error))) => {
+            ink::env::debug_println!("psp22 error: {:?}", psp22_error);
+            Ok(())
+        }
+        Ok(Ok(Ok(res))) => Ok(res),
+    }
+}
+
+// We don't want to fail the whole transaction if PSP22::balance_of fails with a panic either.
+// We choose to use `0` to denote the "panic" scenarios b/c it's a noop for the farm.
+pub fn safe_balance_of<Env: ink::env::Environment>(
+    psp22: &contract_ref!(PSP22, Env),
+    account: UserId,
+) -> u128 {
+    match psp22.call().balance_of(account).try_invoke() {
+        Err(ink_env_err) => {
+            ink::env::debug_println!("ink env error: {:?}", ink_env_err);
+            0
+        }
+        Ok(Err(ink_lang_err)) => {
+            ink::env::debug_println!("ink lang error: {:?}", ink_lang_err);
+            0
+        }
+        Ok(Ok(res)) => res,
+    }
+}

--- a/farm/contracts/instance/views.rs
+++ b/farm/contracts/instance/views.rs
@@ -9,7 +9,7 @@ use ink::{
     primitives::AccountId,
 };
 
-use crate::farm::RewardTokenInfo;
+use crate::reward_token::RewardTokenInfo;
 use scale::{
     Decode,
     Encode,


### PR DESCRIPTION
This PR splits up the code in `instance/lib.rs` into multiple files for better readability:
1. Extract `State` to `state.rs`
2. Extract `RewardTokenInfo` to `reward_token.rs`
3. Extract calculations to `math.rs`
4. Extract `safe_transfer_from` and `safe_balance_of` to `utils.rs`