### PR TITLE
Update tests.rs

### DIFF
--- a/farm/tests/src/tests.rs
+++ b/farm/tests/src/tests.rs
@@ -34,7 +34,8 @@ fn farm_start() {
     assert!(farm_details == expected_details);
 
     // Fix timestamp, otherwise it changes with every invocation.
-    set_timestamp(&mut session, get_timestamp(&mut session));
+    let now =  get_timestamp(&mut session);
+    set_timestamp(&mut session, now);
     let farm_start = now + 100;
     let farm_end = farm_start + 100;
 


### PR DESCRIPTION
During last-minute changes I've remove the intermediate `now` variable and did not re-run the tests.