### PR TITLE
[CMN-306] Command line tool for management of Common Farms

### DIFF
--- a/scripts/commonfarms-cli/README.md
+++ b/scripts/commonfarms-cli/README.md
@@ -1,0 +1,22 @@
+## Command line tool for management of Common Farms
+
+```
+usage: commonfarms-cli [-h] [--chain URL] [--phrase SEED] [--metadata PATH] COMMAND ...
+
+positional arguments:
+  COMMAND
+    create         create a new farm for given trading pool
+    start          schedule a start of an existing farm
+    stop           stop an existing farm
+    withdraw       withdraw to the admin account all available balance of given token
+
+options:
+  -h, --help       show this help message and exit
+  --chain URL      WebSocker URL of the chain (possible shortcuts: mainnet, testnet, local)
+  --phrase SEED    seed phrase of the farm admin account (if not supplied, an interactive prompt will ask for it)
+  --metadata PATH  path to farm contract metadata file
+```
+
+For description of arguments required for each command please use a dedicated help command (e.g `commonfarms-cli start -h`).
+
+**SECURITY WARNING** When interacting with production chains avoid using `--phrase` as it can leave the seed phrase in your cmd history. Skip the `--phrase` parameter and enter your phrase when prompted.

--- a/scripts/commonfarms-cli/commonfarms-cli
+++ b/scripts/commonfarms-cli/commonfarms-cli
@@ -1,0 +1,117 @@
+#!/bin/env python
+
+from argparse import ArgumentParser
+from getpass import getpass
+from os.path import isfile
+from time import time
+
+from substrateinterface import Keypair, SubstrateInterface, ContractCode, ContractInstance, ContractMetadata
+
+
+def argument_parser():
+    """Create command line arguments parser."""
+    parser = ArgumentParser(prog='commonfarms-cli', description='Command line tool for management of Common Farms')
+    parser.add_argument('--chain', metavar='URL', default='local', help='WebSocker URL of the chain (possible shortcuts: mainnet, testnet, local)')
+    parser.add_argument('--phrase', metavar='SEED', help='seed phrase of the farm admin account (if not supplied, an interactive prompt will ask for it)')
+    parser.add_argument('--metadata', metavar='PATH', default='farm_contract.json', help='path to farm contract metadata file')
+    commands = parser.add_subparsers(dest='command', required=True, metavar='COMMAND')
+
+    create = commands.add_parser('create', help='create a new farm for given trading pool')
+    create.add_argument('--pool', required=True, metavar='ACCOUNT_ID', help='contract address of the trading pool')
+    create.add_argument('--rewards', required=True, nargs='+', metavar='ACCOUNT_ID', help='contract addresses of PSP22 tokens distributed as rewards')
+
+    start = commands.add_parser('start', help='schedule a start of an existing farm')
+    start.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
+    start.add_argument('--start', required=True, metavar='TIMESTAMP', type=int, help='start time')
+    start.add_argument('--end', required=True, metavar='TIMESTAMP', type=int, help='end time')
+    start.add_argument('--rewards', required=True, nargs='+', metavar='TIMESTAMP', type=int, help='end time')
+
+    stop = commands.add_parser('stop', help='stop an existing farm')
+    stop.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
+
+    withdraw = commands.add_parser('withdraw', help='withdraw to the admin account all available balance of given token')
+    withdraw.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
+    withdraw.add_argument('--token', required=True, metavar='ACCOUNT_ID', help='contract address of the token')
+
+    return parser
+
+
+def check_address(addr):
+    """Make sure that the provided WebSocket address is legit. Resolve shortcut aliases."""
+    aliases = {
+        'testnet': 'wss://ws.test.azero.dev',
+        'mainnet': 'wss://ws.azero.dev',
+        'local': 'ws://127.0.0.1:9944'
+    }
+    address = aliases.get(addr, addr)
+    if not address.startswith(('wss://', 'ws://')):
+        raise ValueError(f'Invalid WebSocket address: {addr}')
+    return address
+
+
+def check_account_ids(chain, *account_ids):
+    """Make sure that provided AccountIds are correct."""
+    for i in account_ids:
+        if not chain.is_valid_ss58_address(i):
+            raise ValueError(f'Invalid AccountId: {i}')
+
+
+def check_file(path):
+    """Make sure file exists."""
+    if not isfile(path):
+        raise ValueError(f'File does not exist: {path}')
+
+
+def format_call(name, args):
+    """Make a nice string describing call with arguments."""
+    str_args = ', '.join([f'{k}: {v}' for k, v in args.items()])
+    return f'{name}({str_args})'
+
+
+def deploy_contract(chain, keypair, metadata_file, constructor, **kwargs):
+    metadata = ContractMetadata.create_from_file(metadata_file, chain)
+    contract_name = metadata.metadata_dict['contract']['name']
+    code_hash = metadata.metadata_dict['source']['hash']
+    print(f'*** Deploying contract {contract_name} with constructor:\n    {format_call(constructor, kwargs)}')
+    code = ContractCode(code_hash=bytes.fromhex(code_hash[2:]), metadata=metadata, substrate=chain)
+    contract = code.deploy(keypair=keypair, constructor=constructor, args=kwargs, deployment_salt=str(time()), gas_limit={'ref_time': 25990000000, 'proof_size': 119903})
+    print(f'*** Contract deployment successful. Contract address: \n    {contract.contract_address}')
+    return contract
+
+
+def call_contract(chain, keypair, contract_address, metadata_file, method, **kwargs):
+    contract = ContractInstance.create_from_address(contract_address, metadata_file, chain)
+    print(f'*** Calling contract {contract_address} with method:\n    {format_call(method, kwargs)}')
+    receipt = contract.exec(keypair=keypair, method=method, args=kwargs)
+    try:  # remove try block when https://github.com/polkascan/py-substrate-interface/issues/379 is fixed
+        if receipt.is_success:
+            print(f'*** Contract call successful. Extrinsic identifier {receipt.get_extrinsic_identifier()}')
+        else:
+            error = receipt.error_message
+            name, docs = error['name'], error['docs']
+            print(f'!!! Contract call failed with error {name}: {docs}')
+        return receipt
+    except Exception:
+        print('Error decoding ContractExecutionReceipt. Most likely the contract call was still successful')
+
+
+if __name__ == "__main__":
+    args = argument_parser().parse_args()
+    check_file(args.metadata)
+    chain = SubstrateInterface(url=check_address(args.chain), type_registry={"types": {"ContractExecResult": "ContractExecResultTo269"}})
+    if args.phrase is None:
+        args.phrase = getpass('Please enter the seed phrase: ')
+    keypair = Keypair.create_from_uri(args.phrase)
+
+    if args.command == 'create':
+        check_account_ids(chain, args.pool, *args.rewards)
+        deploy_contract(chain, keypair, args.metadata, constructor='new', pool_id=args.pool, reward_tokens=args.rewards)
+    elif args.command == 'start':
+        check_account_ids(chain, args.farm)
+        call_contract(chain, keypair, args.farm, args.metadata, method='Farm::owner_start_new_farm', start=args.start, end=args.end, rewards=args.rewards)
+    elif args.command == 'stop':
+        check_account_ids(chain, args.farm)
+        call_contract(chain, keypair, args.farm, args.metadata, method='Farm::owner_stop_farm')
+    elif args.command == 'withdraw':
+        check_account_ids(chain, args.farm, args.token)
+        call_contract(chain, keypair, args.farm, args.metadata, method='Farm::owner_withdraw_token', token=args.token)

--- a/scripts/commonfarms-cli/farm_contract.json
+++ b/scripts/commonfarms-cli/farm_contract.json
@@ -1,0 +1,1399 @@
+{
+  "source": {
+    "hash": "0x0ee6985140550abcd3840066f823f494605bc8faf5ff751dcfdf0eeb236b6040",
+    "language": "ink! 4.3.0",
+    "compiler": "rustc 1.72.1",
+    "build_info": {
+      "build_mode": "Release",
+      "cargo_contract_version": "3.2.0",
+      "rust_toolchain": "stable-x86_64-unknown-linux-gnu",
+      "wasm_opt_settings": {
+        "keep_debug_symbols": false,
+        "optimization_passes": "Z"
+      }
+    }
+  },
+  "contract": {
+    "name": "farm_contract",
+    "version": "0.1.0",
+    "authors": [
+      "Cardinal Cryptography"
+    ]
+  },
+  "spec": {
+    "constructors": [
+      {
+        "args": [
+          {
+            "label": "pool_id",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          },
+          {
+            "label": "reward_tokens",
+            "type": {
+              "displayName": [
+                "Vec"
+              ],
+              "type": 4
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "new",
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink_primitives",
+            "ConstructorResult"
+          ],
+          "type": 11
+        },
+        "selector": "0x9bae9d5e"
+      }
+    ],
+    "docs": [],
+    "environment": {
+      "accountId": {
+        "displayName": [
+          "AccountId"
+        ],
+        "type": 0
+      },
+      "balance": {
+        "displayName": [
+          "Balance"
+        ],
+        "type": 3
+      },
+      "blockNumber": {
+        "displayName": [
+          "BlockNumber"
+        ],
+        "type": 28
+      },
+      "chainExtension": {
+        "displayName": [
+          "ChainExtension"
+        ],
+        "type": 29
+      },
+      "hash": {
+        "displayName": [
+          "Hash"
+        ],
+        "type": 27
+      },
+      "maxEventTopics": 4,
+      "timestamp": {
+        "displayName": [
+          "Timestamp"
+        ],
+        "type": 5
+      }
+    },
+    "events": [
+      {
+        "args": [
+          {
+            "docs": [],
+            "indexed": true,
+            "label": "account",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          },
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "amount",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 3
+            }
+          }
+        ],
+        "docs": [],
+        "label": "Deposited"
+      },
+      {
+        "args": [
+          {
+            "docs": [],
+            "indexed": true,
+            "label": "account",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          },
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "amount",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 3
+            }
+          }
+        ],
+        "docs": [],
+        "label": "Withdrawn"
+      },
+      {
+        "args": [
+          {
+            "docs": [],
+            "indexed": true,
+            "label": "account",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          },
+          {
+            "docs": [],
+            "indexed": false,
+            "label": "rewards_claimed",
+            "type": {
+              "displayName": [
+                "Vec"
+              ],
+              "type": 6
+            }
+          }
+        ],
+        "docs": [],
+        "label": "RewardsClaimed"
+      }
+    ],
+    "lang_error": {
+      "displayName": [
+        "ink",
+        "LangError"
+      ],
+      "type": 18
+    },
+    "messages": [
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "Farm::pool_id",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 19
+        },
+        "selector": "0x81ea22b0"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "Farm::total_shares",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 20
+        },
+        "selector": "0xe5cc0217"
+      },
+      {
+        "args": [
+          {
+            "label": "owner",
+            "type": {
+              "displayName": [
+                "AccountId"
+              ],
+              "type": 0
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "Farm::shares_of",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 20
+        },
+        "selector": "0xe09bcdb2"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "Farm::reward_tokens",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 21
+        },
+        "selector": "0xb54974fa"
+      },
+      {
+        "args": [
+          {
+            "label": "start",
+            "type": {
+              "displayName": [
+                "Timestamp"
+              ],
+              "type": 5
+            }
+          },
+          {
+            "label": "end",
+            "type": {
+              "displayName": [
+                "Timestamp"
+              ],
+              "type": 5
+            }
+          },
+          {
+            "label": "rewards",
+            "type": {
+              "displayName": [
+                "Vec"
+              ],
+              "type": 6
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "Farm::owner_start_new_farm",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 11
+        },
+        "selector": "0x5a187e78"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "Farm::owner_stop_farm",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 11
+        },
+        "selector": "0xca136e6f"
+      },
+      {
+        "args": [
+          {
+            "label": "token",
+            "type": {
+              "displayName": [
+                "TokenId"
+              ],
+              "type": 0
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "Farm::owner_withdraw_token",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 11
+        },
+        "selector": "0x28d05af5"
+      },
+      {
+        "args": [
+          {
+            "label": "tokens",
+            "type": {
+              "displayName": [
+                "Vec"
+              ],
+              "type": 22
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "Farm::claim_rewards",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 23
+        },
+        "selector": "0x42c83b71"
+      },
+      {
+        "args": [
+          {
+            "label": "amount",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 3
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "Farm::deposit",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 11
+        },
+        "selector": "0x6ae0aec7"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "Farm::deposit_all",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 11
+        },
+        "selector": "0xe9165e6b"
+      },
+      {
+        "args": [
+          {
+            "label": "amount",
+            "type": {
+              "displayName": [
+                "u128"
+              ],
+              "type": 3
+            }
+          }
+        ],
+        "default": false,
+        "docs": [],
+        "label": "Farm::withdraw",
+        "mutates": true,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 11
+        },
+        "selector": "0x8bb10342"
+      },
+      {
+        "args": [],
+        "default": false,
+        "docs": [],
+        "label": "Farm::view_farm_details",
+        "mutates": false,
+        "payable": false,
+        "returnType": {
+          "displayName": [
+            "ink",
+            "MessageResult"
+          ],
+          "type": 25
+        },
+        "selector": "0xd2e7d614"
+      }
+    ]
+  },
+  "storage": {
+    "root": {
+      "layout": {
+        "struct": {
+          "fields": [
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 0
+                }
+              },
+              "name": "pool_id"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 0
+                }
+              },
+              "name": "owner"
+            },
+            {
+              "layout": {
+                "root": {
+                  "layout": {
+                    "leaf": {
+                      "key": "0xb8975302",
+                      "ty": 3
+                    }
+                  },
+                  "root_key": "0xb8975302"
+                }
+              },
+              "name": "shares"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 3
+                }
+              },
+              "name": "total_shares"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 4
+                }
+              },
+              "name": "reward_tokens"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 5
+                }
+              },
+              "name": "start"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 5
+                }
+              },
+              "name": "end"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 5
+                }
+              },
+              "name": "timestamp_at_last_update"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 6
+                }
+              },
+              "name": "farm_distributed_unclaimed_rewards"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 7
+                }
+              },
+              "name": "farm_cumulative_reward_per_share"
+            },
+            {
+              "layout": {
+                "leaf": {
+                  "key": "0x00000000",
+                  "ty": 6
+                }
+              },
+              "name": "farm_reward_rates"
+            },
+            {
+              "layout": {
+                "root": {
+                  "layout": {
+                    "leaf": {
+                      "key": "0x1151aee5",
+                      "ty": 7
+                    }
+                  },
+                  "root_key": "0x1151aee5"
+                }
+              },
+              "name": "user_cumulative_reward_last_update"
+            },
+            {
+              "layout": {
+                "root": {
+                  "layout": {
+                    "leaf": {
+                      "key": "0x61932ad5",
+                      "ty": 6
+                    }
+                  },
+                  "root_key": "0x61932ad5"
+                }
+              },
+              "name": "user_claimable_rewards"
+            }
+          ],
+          "name": "FarmContract"
+        }
+      },
+      "root_key": "0x00000000"
+    }
+  },
+  "types": [
+    {
+      "id": 0,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 1,
+                "typeName": "[u8; 32]"
+              }
+            ]
+          }
+        },
+        "path": [
+          "ink_primitives",
+          "types",
+          "AccountId"
+        ]
+      }
+    },
+    {
+      "id": 1,
+      "type": {
+        "def": {
+          "array": {
+            "len": 32,
+            "type": 2
+          }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "type": {
+        "def": {
+          "primitive": "u8"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "type": {
+        "def": {
+          "primitive": "u128"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 0
+          }
+        }
+      }
+    },
+    {
+      "id": 5,
+      "type": {
+        "def": {
+          "primitive": "u64"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 3
+          }
+        }
+      }
+    },
+    {
+      "id": 7,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 8
+          }
+        }
+      }
+    },
+    {
+      "id": 8,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 9,
+                "typeName": "U256"
+              }
+            ]
+          }
+        },
+        "path": [
+          "amm_helpers",
+          "types",
+          "WrappedU256"
+        ]
+      }
+    },
+    {
+      "id": 9,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 10,
+                "typeName": "[u64; 4]"
+              }
+            ]
+          }
+        },
+        "path": [
+          "primitive_types",
+          "U256"
+        ]
+      }
+    },
+    {
+      "id": 10,
+      "type": {
+        "def": {
+          "array": {
+            "len": 4,
+            "type": 5
+          }
+        }
+      }
+    },
+    {
+      "id": 11,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 12
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 18
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 12
+          },
+          {
+            "name": "E",
+            "type": 18
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 13
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 14
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 13
+          },
+          {
+            "name": "E",
+            "type": 14
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 13,
+      "type": {
+        "def": {
+          "tuple": []
+        }
+      }
+    },
+    {
+      "id": 14,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 15,
+                    "typeName": "PSP22Error"
+                  }
+                ],
+                "index": 0,
+                "name": "PSP22Error"
+              },
+              {
+                "index": 1,
+                "name": "FarmAlreadyRunning"
+              },
+              {
+                "index": 2,
+                "name": "CallerNotOwner"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 17,
+                    "typeName": "MathError"
+                  }
+                ],
+                "index": 3,
+                "name": "ArithmeticError"
+              },
+              {
+                "index": 4,
+                "name": "CallerNotFarmer"
+              },
+              {
+                "index": 5,
+                "name": "AllRewardRatesZero"
+              },
+              {
+                "index": 6,
+                "name": "FarmStartInThePast"
+              },
+              {
+                "index": 7,
+                "name": "FarmEndInThePast"
+              },
+              {
+                "index": 8,
+                "name": "FarmDuration"
+              },
+              {
+                "index": 9,
+                "name": "InsufficientShares"
+              },
+              {
+                "index": 10,
+                "name": "RewardsVecLengthMismatch"
+              },
+              {
+                "index": 11,
+                "name": "TooManyRewardTokens"
+              },
+              {
+                "index": 12,
+                "name": "RewardTokenIsPoolToken"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 0,
+                    "typeName": "AccountId"
+                  },
+                  {
+                    "type": 15,
+                    "typeName": "PSP22Error"
+                  }
+                ],
+                "index": 13,
+                "name": "TokenTransferFailed"
+              }
+            ]
+          }
+        },
+        "path": [
+          "farm_trait",
+          "FarmError"
+        ]
+      }
+    },
+    {
+      "id": 15,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 16,
+                    "typeName": "String"
+                  }
+                ],
+                "index": 0,
+                "name": "Custom"
+              },
+              {
+                "index": 1,
+                "name": "InsufficientBalance"
+              },
+              {
+                "index": 2,
+                "name": "InsufficientAllowance"
+              },
+              {
+                "index": 3,
+                "name": "ZeroRecipientAddress"
+              },
+              {
+                "index": 4,
+                "name": "ZeroSenderAddress"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 16,
+                    "typeName": "String"
+                  }
+                ],
+                "index": 5,
+                "name": "SafeTransferCheckFailed"
+              }
+            ]
+          }
+        },
+        "path": [
+          "psp22",
+          "errors",
+          "PSP22Error"
+        ]
+      }
+    },
+    {
+      "id": 16,
+      "type": {
+        "def": {
+          "primitive": "str"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 2,
+                    "typeName": "u8"
+                  }
+                ],
+                "index": 0,
+                "name": "Overflow"
+              },
+              {
+                "index": 1,
+                "name": "Underflow"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 2,
+                    "typeName": "u8"
+                  }
+                ],
+                "index": 2,
+                "name": "DivByZero"
+              },
+              {
+                "index": 3,
+                "name": "CastOverflow"
+              }
+            ]
+          }
+        },
+        "path": [
+          "amm_helpers",
+          "math",
+          "MathError"
+        ]
+      }
+    },
+    {
+      "id": 18,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "index": 1,
+                "name": "CouldNotReadInput"
+              }
+            ]
+          }
+        },
+        "path": [
+          "ink_primitives",
+          "LangError"
+        ]
+      }
+    },
+    {
+      "id": 19,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 0
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 18
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 0
+          },
+          {
+            "name": "E",
+            "type": 18
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 20,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 3
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 18
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 3
+          },
+          {
+            "name": "E",
+            "type": 18
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 21,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 4
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 18
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 4
+          },
+          {
+            "name": "E",
+            "type": 18
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 22,
+      "type": {
+        "def": {
+          "sequence": {
+            "type": 2
+          }
+        }
+      }
+    },
+    {
+      "id": 23,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 24
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 18
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 24
+          },
+          {
+            "name": "E",
+            "type": 18
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 24,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 6
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 14
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 6
+          },
+          {
+            "name": "E",
+            "type": 14
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 25,
+      "type": {
+        "def": {
+          "variant": {
+            "variants": [
+              {
+                "fields": [
+                  {
+                    "type": 26
+                  }
+                ],
+                "index": 0,
+                "name": "Ok"
+              },
+              {
+                "fields": [
+                  {
+                    "type": 18
+                  }
+                ],
+                "index": 1,
+                "name": "Err"
+              }
+            ]
+          }
+        },
+        "params": [
+          {
+            "name": "T",
+            "type": 26
+          },
+          {
+            "name": "E",
+            "type": 18
+          }
+        ],
+        "path": [
+          "Result"
+        ]
+      }
+    },
+    {
+      "id": 26,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "name": "pool_id",
+                "type": 0,
+                "typeName": "AccountId"
+              },
+              {
+                "name": "start",
+                "type": 5,
+                "typeName": "u64"
+              },
+              {
+                "name": "end",
+                "type": 5,
+                "typeName": "u64"
+              },
+              {
+                "name": "reward_tokens",
+                "type": 4,
+                "typeName": "Vec<AccountId>"
+              },
+              {
+                "name": "reward_rates",
+                "type": 6,
+                "typeName": "Vec<u128>"
+              }
+            ]
+          }
+        },
+        "path": [
+          "farm_trait",
+          "FarmDetails"
+        ]
+      }
+    },
+    {
+      "id": 27,
+      "type": {
+        "def": {
+          "composite": {
+            "fields": [
+              {
+                "type": 1,
+                "typeName": "[u8; 32]"
+              }
+            ]
+          }
+        },
+        "path": [
+          "ink_primitives",
+          "types",
+          "Hash"
+        ]
+      }
+    },
+    {
+      "id": 28,
+      "type": {
+        "def": {
+          "primitive": "u32"
+        }
+      }
+    },
+    {
+      "id": 29,
+      "type": {
+        "def": {
+          "variant": {}
+        },
+        "path": [
+          "ink_env",
+          "types",
+          "NoChainExtension"
+        ]
+      }
+    }
+  ],
+  "version": "4"
+}

--- a/scripts/commonfarms-cli/requirements.txt
+++ b/scripts/commonfarms-cli/requirements.txt
@@ -1,0 +1,1 @@
+substrate-interface==1.7.6


### PR DESCRIPTION
Simple tool to create instances of farm contract and sending "admin" calls (start, stop, withdraw token). Contains a little hack due to a bug discovered in `py-substrate-interface` (PR with fix proposed there)