### PR TITLE
CMN-468: Add possibility for variable fee

### DIFF
--- a/amm/contracts/factory/lib.rs
+++ b/amm/contracts/factory/lib.rs
@@ -86,7 +86,7 @@ pub mod factory {
 
         fn _only_owner(&self) -> Result<(), FactoryError> {
             if self.env().caller() != self.owner {
-                return Err(FactoryError::CallerIsNotFeeSetter);
+                return Err(FactoryError::CallerIsNotOwner);
             }
             Ok(())
         }
@@ -122,7 +122,7 @@ pub mod factory {
                 (token_1, token_0)
             };
             if self.env().caller() != self.owner {
-                ensure!(fee == DEFAULT_FEE, FactoryError::CallerIsNotFeeSetter);
+                ensure!(fee == DEFAULT_FEE, FactoryError::CallerIsNotOwner);
                 ensure!(
                     self.get_pair.get(token_pair).is_none(),
                     FactoryError::PairExists

--- a/amm/contracts/pair/lib.rs
+++ b/amm/contracts/pair/lib.rs
@@ -19,7 +19,6 @@ pub mod pair {
 
     // Whitepaper 3.2.1, equation (11)
     const TRADING_FEE_ADJ_RESERVES: u128 = 1000;
-    const TRADING_FEE_ADJ_AMOUNTS: u128 = 3;
 
     // Whitepaper 2.4, equation (7)
     const PROTOCOL_FEE_ADJ_DENOM: u128 = 5;
@@ -110,10 +109,11 @@ pub mod pair {
         pub price_0_cumulative_last: WrappedU256,
         pub price_1_cumulative_last: WrappedU256,
         pub k_last: Option<WrappedU256>,
+        pub fee: u8,
     }
 
     impl PairData {
-        fn new(token_0: AccountId, token_1: AccountId, factory: AccountId) -> Self {
+        fn new(token_0: AccountId, token_1: AccountId, factory: AccountId, fee: u8) -> Self {
             Self {
                 factory,
                 token_0,
@@ -124,6 +124,7 @@ pub mod pair {
                 price_0_cumulative_last: 0.into(),
                 price_1_cumulative_last: 0.into(),
                 k_last: None,
+                fee,
             }
         }
     }
@@ -136,8 +137,8 @@ pub mod pair {
 
     impl PairContract {
         #[ink(constructor)]
-        pub fn new(token_0: AccountId, token_1: AccountId) -> Self {
-            let pair = PairData::new(token_0, token_1, Self::env().caller());
+        pub fn new(token_0: AccountId, token_1: AccountId, fee: u8) -> Self {
+            let pair = PairData::new(token_0, token_1, Self::env().caller(), fee);
             Self {
                 psp22: PSP22Data::default(),
                 pair,
@@ -290,11 +291,12 @@ pub mod pair {
         }
 
         #[ink(message)]
-        fn get_reserves(&self) -> (u128, u128, u32) {
+        fn get_reserves(&self) -> (u128, u128, u32, u8) {
             (
                 self.pair.reserve_0,
                 self.pair.reserve_1,
                 self.pair.block_timestamp_last,
+                self.pair.fee,
             )
         }
         #[ink(message)]
@@ -491,7 +493,7 @@ pub mod pair {
                 .ok_or(MathError::MulOverflow(3))?
                 .checked_sub(
                     amount_0_in
-                        .checked_mul(TRADING_FEE_ADJ_AMOUNTS)
+                        .checked_mul(self.pair.fee.into())
                         .ok_or(MathError::MulOverflow(4))?,
                 )
                 .ok_or(MathError::SubUnderflow(9))?;
@@ -500,7 +502,7 @@ pub mod pair {
                 .ok_or(MathError::MulOverflow(5))?
                 .checked_sub(
                     amount_1_in
-                        .checked_mul(TRADING_FEE_ADJ_AMOUNTS)
+                        .checked_mul(self.pair.fee.into())
                         .ok_or(MathError::MulOverflow(6))?,
                 )
                 .ok_or(MathError::SubUnderflow(10))?;
@@ -563,6 +565,11 @@ pub mod pair {
         #[ink(message)]
         fn get_token_1(&self) -> AccountId {
             self.pair.token_1
+        }
+
+        #[ink(message)]
+        fn get_fee(&self) -> u8 {
+            self.pair.fee
         }
     }
 
@@ -735,9 +742,11 @@ pub mod pair {
         fn initialize_works() {
             let token_0 = AccountId::from([0x03; 32]);
             let token_1 = AccountId::from([0x04; 32]);
-            let pair = PairContract::new(token_0, token_1);
+            let fee = 3;
+            let pair = PairContract::new(token_0, token_1, fee);
             assert_eq!(pair.get_token_0(), token_0);
             assert_eq!(pair.get_token_1(), token_1);
+            assert_eq!(pair.get_fee(), fee);
         }
 
         #[ink::test]

--- a/amm/traits/Cargo.lock
+++ b/amm/traits/Cargo.lock
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "psp22"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701aea3ff70bbecb49f4a664d25292076f13bbe5592406e2ca4bddf448c37fe0"
+checksum = "5a9bdae21c2e17b9501b2c3f8597a679cfbe2f81ec5432091bd8d4b156f66194"
 dependencies = [
  "ink",
  "parity-scale-codec",

--- a/amm/traits/factory.rs
+++ b/amm/traits/factory.rs
@@ -56,7 +56,7 @@ pub trait Factory {
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub enum FactoryError {
     PairError(PairError),
-    CallerIsNotFeeSetter,
+    CallerIsNotOwner,
     IdenticalAddresses,
     PairExists,
     PairInstantiationFailed,

--- a/amm/traits/factory.rs
+++ b/amm/traits/factory.rs
@@ -27,23 +27,24 @@ pub trait Factory {
         &mut self,
         token_0: AccountId,
         token_1: AccountId,
+        fee: u8,
     ) -> Result<AccountId, FactoryError>;
 
     /// Sets the address for receiving protocol's share of trading fees.
     #[ink(message)]
     fn set_fee_to(&mut self, fee_to: AccountId) -> Result<(), FactoryError>;
 
-    /// Sets the address eligible for calling `set_foo_to` method.
+    /// Sets the owner address.
     #[ink(message)]
-    fn set_fee_to_setter(&mut self, fee_to_setter: AccountId) -> Result<(), FactoryError>;
+    fn set_owner(&mut self, owner: AccountId) -> Result<(), FactoryError>;
 
     /// Returns recipient address of the trading fees.
     #[ink(message)]
     fn fee_to(&self) -> Option<AccountId>;
 
-    /// Returns account allowed to call `set_fee_to_setter`.
+    /// Returns owner account address.
     #[ink(message)]
-    fn fee_to_setter(&self) -> AccountId;
+    fn owner(&self) -> AccountId;
 
     /// Returns address of `Pair` contract instance (if any) for `(token_0, token_1)` pair.
     #[ink(message)]

--- a/amm/traits/lib.rs
+++ b/amm/traits/lib.rs
@@ -7,6 +7,8 @@ mod swap_callee;
 
 pub type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Balance;
 
+pub const DEFAULT_FEE: u8 = 3;
+
 pub use factory::{Factory, FactoryError};
 pub use pair::{Pair, PairError};
 pub use router::{Router, RouterError};

--- a/amm/traits/pair.rs
+++ b/amm/traits/pair.rs
@@ -19,7 +19,7 @@ pub trait Pair {
     /// NOTE: This does not include the tokens that were transferred to the contract
     /// as part of the _current_ transaction.
     #[ink(message)]
-    fn get_reserves(&self) -> (u128, u128, u32);
+    fn get_reserves(&self) -> (u128, u128, u32, u8);
 
     /// Returns cumulative prive of the first token.
     ///
@@ -82,6 +82,10 @@ pub trait Pair {
     /// Returns address of the second token.
     #[ink(message)]
     fn get_token_1(&self) -> AccountId;
+
+    /// Returns protocol fee (in millis).
+    #[ink(message)]
+    fn get_fee(&self) -> u8;
 }
 
 #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]

--- a/amm/traits/router.rs
+++ b/amm/traits/router.rs
@@ -194,6 +194,7 @@ pub trait Router {
         amount_in: u128,
         reserve_0: u128,
         reserve_1: u128,
+        fee: u8,
     ) -> Result<u128, RouterError>;
 
     /// Returns amount of `A` tokens user has to supply
@@ -205,6 +206,7 @@ pub trait Router {
         amount_out: u128,
         reserve_0: u128,
         reserve_1: u128,
+        fee: u8,
     ) -> Result<u128, RouterError>;
 
     /// Returns amounts of tokens received for `amount_in`.


### PR DESCRIPTION
_Marking as draft since I'd like to discuss if this is the right approach before finishing with all the tests, pipelines etc._

This PR introduces the following changes:
1. Trading fee is no longer constant 0.3%
2. Fee is stored as `u8` millis, that means possible values are 0.1%-25.5%, with 0.1% step
3. Fee is set in Pair constructor and its value cannot be changed
4. `get_reserves` returns also fee value (to avoid having to call Pair twice when calculating amounts in/out in Router)
5. Factory `fee_to_setter` is renamed to "owner". Only owner can create pairs with non-default fee. Owner can also replace the existing pair with a new one.
6. Router takes variable fee into account while calculating token amounts.
7. Router has a method to update its pair cache for cases in which Pair was not created via Router.

What I'm not sure about is the following scenario:
- someone creates a default fee pair for tokens A and B
- owner wants to replace it with a new pair with different fee
- should the `all_pairs` list in factory contain BOTH these pairs, or should the new one replace the old one? Currently they are both added.