### PR TITLE
CMN-468: Variable fee pair via owner in Router

### DIFF
--- a/amm/contracts/factory/lib.rs
+++ b/amm/contracts/factory/lib.rs
@@ -2,6 +2,7 @@
 
 #[ink::contract]
 pub mod factory {
+    const DEFAULT_FEE: u8 = 3;
     use amm_helpers::ensure;
     use ink::{codegen::EmitEvent, env::hash::Blake2x256, storage::Mapping, ToAccountId};
     use pair_contract::pair::PairContractRef;
@@ -47,7 +48,7 @@ pub mod factory {
             token_1: AccountId,
         ) -> Result<AccountId, FactoryError> {
             let pair_hash = self.pair_contract_code_hash;
-            let pair = match PairContractRef::new(token_0, token_1)
+            let pair = match PairContractRef::new(token_0, token_1, DEFAULT_FEE)
                 .endowment(0)
                 .code_hash(pair_hash)
                 .salt_bytes(&salt_bytes)

--- a/amm/contracts/factory/lib.rs
+++ b/amm/contracts/factory/lib.rs
@@ -48,15 +48,16 @@ pub mod factory {
             token_1: AccountId,
         ) -> Result<AccountId, FactoryError> {
             let pair_hash = self.pair_contract_code_hash;
-            let pair = match PairContractRef::new(token_0, token_1, DEFAULT_FEE)
-                .endowment(0)
-                .code_hash(pair_hash)
-                .salt_bytes(&salt_bytes)
-                .try_instantiate()
-            {
-                Ok(Ok(res)) => Ok(res),
-                _ => Err(FactoryError::PairInstantiationFailed),
-            }?;
+            let pair =
+                match PairContractRef::new(token_0, token_1, self.env().account_id(), DEFAULT_FEE)
+                    .endowment(0)
+                    .code_hash(pair_hash)
+                    .salt_bytes(&salt_bytes)
+                    .try_instantiate()
+                {
+                    Ok(Ok(res)) => Ok(res),
+                    _ => Err(FactoryError::PairInstantiationFailed),
+                }?;
             Ok(pair.to_account_id())
         }
 

--- a/amm/contracts/factory/lib.rs
+++ b/amm/contracts/factory/lib.rs
@@ -2,6 +2,7 @@
 
 #[ink::contract]
 pub mod factory {
+    // All pairs created via this factory have fixed fee of 0.3%
     const DEFAULT_FEE: u8 = 3;
     use amm_helpers::ensure;
     use ink::{codegen::EmitEvent, env::hash::Blake2x256, storage::Mapping, ToAccountId};

--- a/amm/contracts/pair/lib.rs
+++ b/amm/contracts/pair/lib.rs
@@ -19,7 +19,6 @@ pub mod pair {
 
     // Whitepaper 3.2.1, equation (11)
     const TRADING_FEE_ADJ_RESERVES: u128 = 1000;
-    const TRADING_FEE_ADJ_AMOUNTS: u128 = 3;
 
     // Whitepaper 2.4, equation (7)
     const PROTOCOL_FEE_ADJ_DENOM: u128 = 5;
@@ -110,10 +109,11 @@ pub mod pair {
         pub price_0_cumulative_last: WrappedU256,
         pub price_1_cumulative_last: WrappedU256,
         pub k_last: Option<WrappedU256>,
+        pub fee: u8,
     }
 
     impl PairData {
-        fn new(token_0: AccountId, token_1: AccountId, factory: AccountId) -> Self {
+        fn new(token_0: AccountId, token_1: AccountId, factory: AccountId, fee: u8) -> Self {
             Self {
                 factory,
                 token_0,
@@ -124,6 +124,7 @@ pub mod pair {
                 price_0_cumulative_last: 0.into(),
                 price_1_cumulative_last: 0.into(),
                 k_last: None,
+                fee,
             }
         }
     }
@@ -136,8 +137,8 @@ pub mod pair {
 
     impl PairContract {
         #[ink(constructor)]
-        pub fn new(token_0: AccountId, token_1: AccountId) -> Self {
-            let pair = PairData::new(token_0, token_1, Self::env().caller());
+        pub fn new(token_0: AccountId, token_1: AccountId, fee: u8) -> Self {
+            let pair = PairData::new(token_0, token_1, Self::env().caller(), fee);
             Self {
                 psp22: PSP22Data::default(),
                 pair,
@@ -290,11 +291,12 @@ pub mod pair {
         }
 
         #[ink(message)]
-        fn get_reserves(&self) -> (u128, u128, u32) {
+        fn get_reserves(&self) -> (u128, u128, u32, u8) {
             (
                 self.pair.reserve_0,
                 self.pair.reserve_1,
                 self.pair.block_timestamp_last,
+                self.pair.fee,
             )
         }
         #[ink(message)]
@@ -491,7 +493,7 @@ pub mod pair {
                 .ok_or(MathError::MulOverflow(3))?
                 .checked_sub(
                     amount_0_in
-                        .checked_mul(TRADING_FEE_ADJ_AMOUNTS)
+                        .checked_mul(self.pair.fee.into())
                         .ok_or(MathError::MulOverflow(4))?,
                 )
                 .ok_or(MathError::SubUnderflow(9))?;
@@ -500,7 +502,7 @@ pub mod pair {
                 .ok_or(MathError::MulOverflow(5))?
                 .checked_sub(
                     amount_1_in
-                        .checked_mul(TRADING_FEE_ADJ_AMOUNTS)
+                        .checked_mul(self.pair.fee.into())
                         .ok_or(MathError::MulOverflow(6))?,
                 )
                 .ok_or(MathError::SubUnderflow(10))?;
@@ -563,6 +565,11 @@ pub mod pair {
         #[ink(message)]
         fn get_token_1(&self) -> AccountId {
             self.pair.token_1
+        }
+
+        #[ink(message)]
+        fn get_fee(&self) -> u8 {
+            self.pair.fee
         }
     }
 
@@ -735,9 +742,11 @@ pub mod pair {
         fn initialize_works() {
             let token_0 = AccountId::from([0x03; 32]);
             let token_1 = AccountId::from([0x04; 32]);
-            let pair = PairContract::new(token_0, token_1);
+            let fee = 3;
+            let pair = PairContract::new(token_0, token_1, fee);
             assert_eq!(pair.get_token_0(), token_0);
             assert_eq!(pair.get_token_1(), token_1);
+            assert_eq!(pair.get_fee(), fee);
         }
 
         #[ink::test]

--- a/amm/contracts/pair/lib.rs
+++ b/amm/contracts/pair/lib.rs
@@ -138,7 +138,11 @@ pub mod pair {
     impl PairContract {
         #[ink(constructor)]
         pub fn new(token_0: AccountId, token_1: AccountId, factory: AccountId, fee: u8) -> Self {
-            let pair = PairData::new(token_0, token_1, factory, fee);
+            let pair = if token_0 < token_1 {
+                PairData::new(token_0, token_1, factory, fee)
+            } else {
+                PairData::new(token_1, token_0, factory, fee)
+            };
             Self {
                 psp22: PSP22Data::default(),
                 pair,

--- a/amm/contracts/pair/lib.rs
+++ b/amm/contracts/pair/lib.rs
@@ -291,12 +291,11 @@ pub mod pair {
         }
 
         #[ink(message)]
-        fn get_reserves(&self) -> (u128, u128, u32, u8) {
+        fn get_reserves(&self) -> (u128, u128, u32) {
             (
                 self.pair.reserve_0,
                 self.pair.reserve_1,
                 self.pair.block_timestamp_last,
-                self.pair.fee,
             )
         }
         #[ink(message)]

--- a/amm/contracts/pair/lib.rs
+++ b/amm/contracts/pair/lib.rs
@@ -137,8 +137,8 @@ pub mod pair {
 
     impl PairContract {
         #[ink(constructor)]
-        pub fn new(token_0: AccountId, token_1: AccountId, fee: u8) -> Self {
-            let pair = PairData::new(token_0, token_1, Self::env().caller(), fee);
+        pub fn new(token_0: AccountId, token_1: AccountId, factory: AccountId, fee: u8) -> Self {
+            let pair = PairData::new(token_0, token_1, factory, fee);
             Self {
                 psp22: PSP22Data::default(),
                 pair,
@@ -742,10 +742,12 @@ pub mod pair {
         fn initialize_works() {
             let token_0 = AccountId::from([0x03; 32]);
             let token_1 = AccountId::from([0x04; 32]);
+            let factory = AccountId::from([0x05; 32]);
             let fee = 3;
-            let pair = PairContract::new(token_0, token_1, fee);
+            let pair = PairContract::new(token_0, token_1, factory, fee);
             assert_eq!(pair.get_token_0(), token_0);
             assert_eq!(pair.get_token_1(), token_1);
+            assert_eq!(pair.get_factory(), factory);
             assert_eq!(pair.get_fee(), fee);
         }
 

--- a/amm/contracts/router/lib.rs
+++ b/amm/contracts/router/lib.rs
@@ -80,6 +80,21 @@ pub mod router {
             Ok(())
         }
 
+        #[ink(message)]
+        pub fn clear_pair(
+            &mut self,
+            token_0: AccountId,
+            token_1: AccountId,
+        ) -> Result<(), RouterOwnerError> {
+            ensure!(
+                self.env().caller() == self.owner,
+                RouterOwnerError::CallerIsNotOwner
+            );
+            self.pairs.remove((token_0, token_1));
+            self.pairs.remove((token_1, token_0));
+            Ok(())
+        }
+
         #[inline]
         fn factory_ref(&self) -> contract_ref!(Factory) {
             self.factory.into()

--- a/amm/drink-tests/Cargo.lock
+++ b/amm/drink-tests/Cargo.lock
@@ -37,16 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array 0.14.7",
-]
-
-[[package]]
 name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1da02abba9f9063d786eab1509833ebb2fac0f966862ca59439c76b9c566760"
 dependencies = [
  "include_dir",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -290,12 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,46 +378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
-dependencies = [
- "base64 0.21.7",
- "bollard-stubs",
- "bytes",
- "futures-core",
- "futures-util",
- "hex",
- "http",
- "hyper",
- "hyperlocal",
- "log",
- "pin-project-lite",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_repr",
- "serde_urlencoded",
- "thiserror",
- "tokio",
- "tokio-util",
- "url",
- "winapi",
-]
-
-[[package]]
-name = "bollard-stubs"
-version = "1.43.0-rc.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
-dependencies = [
- "serde",
- "serde_repr",
- "serde_with",
-]
-
-[[package]]
 name = "bounded-collections"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +463,20 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
@@ -565,7 +523,6 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "serde",
  "windows-targets 0.48.5",
 ]
 
@@ -668,26 +625,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_env"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9e4f72c6e3398ca6da372abd9affd8f89781fe728869bbf986206e9af9627e"
-dependencies = [
- "const_env_impl",
-]
-
-[[package]]
-name = "const_env_impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4f51209740b5e1589e702b3044cdd4562cef41b6da404904192ffffb852d62"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,38 +632,32 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "contract-build"
-version = "4.0.0-rc.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4998e19b98b55fb9c1b5f1c93bb1678ab64c96eb9216b4a10fdb9a521717fcf"
+checksum = "ae1c9e0b024481d35d46e1043323ec8c1dc8b57f4a08c4ee5392c2aefb75859b"
 dependencies = [
  "anyhow",
  "blake2",
- "bollard",
- "cargo_metadata",
+ "cargo_metadata 0.15.4",
  "clap",
  "colored",
  "contract-metadata",
- "crossterm",
  "duct",
  "heck",
  "hex",
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
- "regex",
  "rustc_version",
  "semver",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum",
  "tempfile",
  "term_size",
- "tokio",
- "tokio-stream",
- "toml",
+ "toml 0.7.8",
  "tracing",
  "url",
- "users",
  "walkdir",
  "wasm-opt",
  "which",
@@ -735,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "contract-metadata"
-version = "4.0.0-rc.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f0ed28c6af5080a0cf0e4b943fc7eeb42731aee2e2154735b8c5ddd19cc412"
+checksum = "39a88f62795e84270742796456086ddeebfa4cbd4e56f02777f792192d666725"
 dependencies = [
  "anyhow",
  "impl-serde",
@@ -749,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "contract-transcode"
-version = "4.0.0-rc.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ec69b9877e7565a9bb95040358149637714d0a422f67be9eff5a42c1ee86e"
+checksum = "91279ca8e8a05dec90febb12a9529b310018c623adaebe691d9b2e8cc115a182"
 dependencies = [
  "anyhow",
  "base58",
@@ -759,10 +690,10 @@ dependencies = [
  "contract-metadata",
  "escape8259",
  "hex",
- "indexmap 2.1.0",
+ "indexmap 1.9.3",
  "ink_env",
- "ink_metadata 5.0.0-rc",
- "itertools 0.12.0",
+ "ink_metadata 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools",
  "nom",
  "nom-supreme",
  "parity-scale-codec",
@@ -770,7 +701,6 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "strsim",
  "thiserror",
  "tracing",
 ]
@@ -833,31 +763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.4.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -946,7 +850,6 @@ dependencies = [
  "platforms",
  "rustc_version",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -1085,16 +988,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
- "serde",
-]
-
-[[package]]
 name = "derive-syn-parse"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,7 +1062,7 @@ dependencies = [
  "regex",
  "syn 2.0.48",
  "termcolor",
- "toml",
+ "toml 0.8.8",
  "walkdir",
 ]
 
@@ -1181,9 +1074,9 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "drink"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af1b156accb976b3267e114d60ef6ec1075f3be58fc667de7745306ae0f46fd"
+checksum = "080eec4536bfe740b58a55418eb7e76eb2ffdd88b3e7978d752d6f6233de39b6"
 dependencies = [
  "contract-metadata",
  "contract-transcode",
@@ -1203,16 +1096,17 @@ dependencies = [
  "sp-io",
  "sp-runtime-interface",
  "thiserror",
+ "wasm-instrument",
  "wat",
 ]
 
 [[package]]
 name = "drink-test-macro"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4463d6959118375d87065e1dae96c58ad65e98a62b71c86f65e1ad08715408"
+checksum = "1f10924a75fb62a42e8991217a69f86c0a381518aa5c783f1f39cf8ab9b721a5"
 dependencies = [
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "contract-build",
  "contract-metadata",
  "convert_case",
@@ -1530,7 +1424,7 @@ dependencies = [
  "derive-syn-parse",
  "expander",
  "frame-support-procedural-tools",
- "itertools 0.10.5",
+ "itertools",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
@@ -1730,16 +1624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom_or_panic"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
-dependencies = [
- "rand 0.8.5",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,25 +1649,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap 2.1.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1890,77 +1755,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "hyper"
-version = "0.14.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyperlocal"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
-dependencies = [
- "futures-util",
- "hex",
- "hyper",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -2075,7 +1869,6 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
- "serde",
 ]
 
 [[package]]
@@ -2092,7 +1885,7 @@ dependencies = [
  "ahash 0.8.7",
  "anyhow",
  "drink",
- "ink_metadata 4.3.0",
+ "ink_metadata 4.3.0 (git+https://github.com/paritytech/ink?rev=v4.3.0)",
  "ink_primitives 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "thiserror",
@@ -2100,42 +1893,42 @@ dependencies = [
 
 [[package]]
 name = "ink_allocator"
-version = "5.0.0-rc"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1d2eddb445b3ef076dacaa9968a7ff5b80ad5b9b724966fab66a8f4e48bde4"
+checksum = "870914970470fd77a3f42d3c5d1918b562817af127fd063ee8b1d9fbf59aa1fe"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "ink_engine"
-version = "5.0.0-rc"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99aae25c6820d9e9dae12f79df79a10cba3c961fe1204a68fefaf72f9ae7b14"
+checksum = "722ec3a5eb557124b001c60ff8f961079f6d566af643edea579f152b15822fe5"
 dependencies = [
  "blake2",
  "derive_more",
- "ink_primitives 5.0.0-rc",
+ "ink_primitives 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "secp256k1 0.28.1",
+ "secp256k1 0.27.0",
  "sha2 0.10.8",
  "sha3",
 ]
 
 [[package]]
 name = "ink_env"
-version = "5.0.0-rc"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8f814ac18100f5ba3d265fbc29e1639325660571883184bedf31dcfecd2428"
+checksum = "584e73bc0982f6f1a067bb63ebc75262f6dc54ed2a17060efa73eaba84dc9308"
 dependencies = [
+ "arrayref",
  "blake2",
  "cfg-if",
- "const_env",
  "derive_more",
  "ink_allocator",
  "ink_engine",
- "ink_prelude 5.0.0-rc",
- "ink_primitives 5.0.0-rc",
+ "ink_prelude 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ink_storage_traits",
  "num-traits",
  "parity-scale-codec",
@@ -2144,11 +1937,24 @@ dependencies = [
  "scale-decode",
  "scale-encode",
  "scale-info",
- "schnorrkel 0.11.4",
- "secp256k1 0.28.1",
+ "secp256k1 0.27.0",
  "sha2 0.10.8",
  "sha3",
  "static_assertions",
+]
+
+[[package]]
+name = "ink_metadata"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fddff95ce3e01f42002fdaf96edda691dbccb08c9ae76d7101daa1fa634e601"
+dependencies = [
+ "derive_more",
+ "impl-serde",
+ "ink_prelude 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scale-info",
+ "serde",
 ]
 
 [[package]]
@@ -2165,22 +1971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_metadata"
-version = "5.0.0-rc"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75859c7142101f3ad30a763fd0e5468df164e3d424086df8de40531fb54940f3"
-dependencies = [
- "derive_more",
- "impl-serde",
- "ink_prelude 5.0.0-rc",
- "ink_primitives 5.0.0-rc",
- "linkme",
- "scale-info",
- "schemars",
- "serde",
-]
-
-[[package]]
 name = "ink_prelude"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,15 +1983,6 @@ dependencies = [
 name = "ink_prelude"
 version = "4.3.0"
 source = "git+https://github.com/paritytech/ink?rev=v4.3.0#71c817c596699ce5518ead95003182cc35c5902d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "ink_prelude"
-version = "5.0.0-rc"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3fbd55e0cf78e456ad4a92558d55b577bf65944bb37bf7debb8f03ed66a47b"
 dependencies = [
  "cfg-if",
 ]
@@ -2236,29 +2017,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ink_primitives"
-version = "5.0.0-rc"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c976554c1bd075c6722d0f30cc3a8337b7ebaf487b95a40c9e81097d995f921"
-dependencies = [
- "derive_more",
- "ink_prelude 5.0.0-rc",
- "parity-scale-codec",
- "scale-decode",
- "scale-encode",
- "scale-info",
- "xxhash-rust",
-]
-
-[[package]]
 name = "ink_storage_traits"
-version = "5.0.0-rc"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a469c01b48282a459130ca72a75e57feedbb69ab151639f532156d10d574353"
+checksum = "a8dcb50f70377ac35c28d63b06383a0a3cbb79542ea4cdc5b00e3e2b3de4a549"
 dependencies = [
- "ink_metadata 5.0.0-rc",
- "ink_prelude 5.0.0-rc",
- "ink_primitives 5.0.0-rc",
+ "ink_metadata 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_prelude 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ink_primitives 4.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -2299,15 +2065,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -2395,7 +2152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
 dependencies = [
  "arrayref",
- "base64 0.13.1",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg",
  "libsecp256k1-core",
@@ -2443,26 +2200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "linkme"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b53ad6a33de58864705954edb5ad5d571a010f9e296865ed43dc72a5621b430"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e542a18c94a9b6fcc7adb090fa3ba6b79ee220a16404f325672729f32a66ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -2624,18 +2361,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,18 +2373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3004,26 +2717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,12 +2743,6 @@ name = "platforms"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3487,7 +3174,6 @@ dependencies = [
  "derive_more",
  "parity-scale-codec",
  "scale-info-derive",
- "schemars",
  "serde",
 ]
 
@@ -3500,30 +3186,6 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "schemars"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
  "syn 1.0.109",
 ]
 
@@ -3548,29 +3210,10 @@ dependencies = [
  "arrayvec 0.5.2",
  "curve25519-dalek 2.1.3",
  "getrandom 0.1.16",
- "merlin 2.0.1",
+ "merlin",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "schnorrkel"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de18f6d8ba0aad7045f5feae07ec29899c1112584a38509a84ad7b04451eaa0"
-dependencies = [
- "aead",
- "arrayref",
- "arrayvec 0.7.4",
- "curve25519-dalek 4.1.1",
- "getrandom_or_panic",
- "merlin 3.0.0",
- "rand_core 0.6.4",
- "serde_bytes",
- "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -3612,11 +3255,11 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f622567e3b4b38154fb8190bcf6b160d7a4301d70595a49195b48c116007a27"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
- "secp256k1-sys 0.9.2",
+ "secp256k1-sys 0.8.1",
 ]
 
 [[package]]
@@ -3630,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.9.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -3665,15 +3308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3682,17 +3316,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3707,51 +3330,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
-dependencies = [
- "base64 0.21.7",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.1.0",
- "serde",
- "serde_json",
- "time",
 ]
 
 [[package]]
@@ -3820,36 +3404,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,16 +3440,6 @@ name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
-
-[[package]]
-name = "socket2"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "sp-api"
@@ -3984,7 +3528,7 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "merlin 2.0.1",
+ "merlin",
  "parity-scale-codec",
  "parking_lot",
  "paste",
@@ -3992,7 +3536,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "scale-info",
- "schnorrkel 0.9.1",
+ "schnorrkel",
  "secp256k1 0.24.3",
  "secrecy",
  "serde",
@@ -4423,14 +3967,8 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros",
 ]
 
 [[package]]
@@ -4447,19 +3985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "substrate-bip39"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4467,7 +3992,7 @@ checksum = "e620c7098893ba667438b47169c00aacdd9e7c10e042250ce2b60b087ec97328"
 dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
- "schnorrkel 0.9.1",
+ "schnorrkel",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -4575,35 +4100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
-dependencies = [
- "deranged",
- "itoa",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
-dependencies = [
- "time-core",
-]
-
-[[package]]
 name = "tiny-bip39"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4647,56 +4143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.35.1"
+name = "toml"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "backtrace",
- "bytes",
- "libc",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2",
- "tokio-macros",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -4727,6 +4182,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -4754,12 +4211,6 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -4859,12 +4310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "tt-call"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4952,16 +4397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4987,15 +4422,6 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -5084,14 +4510,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt"
-version = "0.116.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
+checksum = "65a2799e08026234b07b44da6363703974e75be21430cef00756bbc438c8ff8a"
 dependencies = [
  "anyhow",
  "libc",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum",
+ "strum_macros",
  "tempfile",
  "thiserror",
  "wasm-opt-cxx-sys",
@@ -5100,9 +4526,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-cxx-sys"
-version = "0.116.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
+checksum = "c8d26f86d1132245e8bcea8fac7f02b10fb885b6696799969c94d7d3c14db5e1"
 dependencies = [
  "anyhow",
  "cxx",
@@ -5112,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-opt-sys"
-version = "0.116.0"
+version = "0.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
+checksum = "497d069cd3420cdd52154a320b901114a20946878e2de62c670f9d906e472370"
 dependencies = [
  "anyhow",
  "cc",
@@ -5327,15 +4753,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "5.0.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix 0.38.30",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/amm/drink-tests/Cargo.toml
+++ b/amm/drink-tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-drink = "0.8.6"
+drink = "0.8.7"
 ink-wrapper-types = { git = "https://github.com/Cardinal-Cryptography/ink-wrapper", rev = "47ba45b", default-features = false, features = [
     "drink",
 ] }

--- a/amm/drink-tests/src/router_tests.rs
+++ b/amm/drink-tests/src/router_tests.rs
@@ -444,7 +444,7 @@ fn test_custom_fee(mut session: Session) {
     // but it should be close to the expected value
     let received_protocol_fees = protocol_fees_ice + protocol_fees_wood;
 
-    // Trading fee is 0.3%.
+    // Trading fee is 0.1%.
     let trading_fee = (session
         .query(ice_wood_pair.get_fee())
         .unwrap()
@@ -459,7 +459,7 @@ fn test_custom_fee(mut session: Session) {
     //
     // This makes it dynamic and hard to predict. So we're setting lower & upper bounds.
 
-    // Lower bound for the received protocol fees is the exact 0.3%/6 of the output amount.
+    // Lower bound for the received protocol fees is the exact 0.1%/6 of the output amount.
     let expected_protocol_fees = (swap_res[1] as f64 * trading_fee) / 6.0;
     // Upper bound for the received protocol fees is the % from the input amount.
     let expected_with_imp_loss = (swap_res[0] as f64 * trading_fee) / 6.0;

--- a/amm/drink-tests/src/router_tests.rs
+++ b/amm/drink-tests/src/router_tests.rs
@@ -115,7 +115,7 @@ fn add_liquidity_collects_too_much_fee(mut session: Session) {
         .unwrap()
         .unwrap();
 
-    let token_amount = 1_000 * 10u128.pow(18);
+    let token_amount = 1_000 * TOKEN;
     psp22_utils::increase_allowance(&mut session, ice.into(), router.into(), u128::MAX, BOB)
         .unwrap();
     psp22_utils::increase_allowance(&mut session, wood.into(), router.into(), u128::MAX, BOB)
@@ -190,8 +190,7 @@ fn test_fees(mut session: Session) {
         .unwrap()
         .unwrap();
 
-    let exp = 10u128.pow(18);
-    let token_amount = 1_000_000 * exp;
+    let token_amount = 1_000_000 * TOKEN;
     psp22_utils::increase_allowance(&mut session, ice.into(), router.into(), u128::MAX, BOB)
         .unwrap();
     psp22_utils::increase_allowance(&mut session, wood.into(), router.into(), u128::MAX, BOB)
@@ -215,8 +214,169 @@ fn test_fees(mut session: Session) {
     let bob_lp_balance: u128 = psp22_utils::balance_of(&mut session, ice_wood_pair.into(), bob());
     assert_eq!(liquidity_minted, bob_lp_balance);
 
-    let swap_amount = 10_000 * exp;
+    let swap_amount = 10_000 * TOKEN;
     // 0.3% is would be 30 tokens exactly but due to rounding we can lose up to 1 dust.
+    let swap_res = session
+        .execute(router.swap_exact_tokens_for_tokens(
+            swap_amount,
+            0,
+            vec![ice.into(), wood.into()],
+            bob(),
+            deadline,
+        ))
+        .unwrap()
+        .result
+        .unwrap()
+        .unwrap();
+
+    // We cannot assert that as it depends on the pool's liquidity and swap amount. The price will move from the spot price.
+    // assert!(swap_res[1] >= min_amount_out);
+
+    // No fees distributed until the burn/mint transaction.
+    assert!(psp22_utils::balance_of(&mut session, ice_wood_pair.into(), charlie()) == 0);
+    // Burn some liquidity to trigger fee collection.
+    psp22_utils::increase_allowance(
+        &mut session,
+        ice_wood_pair.into(),
+        router.into(),
+        liquidity_minted,
+        BOB,
+    )
+    .unwrap();
+    let (_ice, _wood) = session
+        .execute(router.remove_liquidity(
+            ice.into(),
+            wood.into(),
+            liquidity_minted,
+            0,
+            0,
+            bob(),
+            deadline,
+        ))
+        .unwrap()
+        .result
+        .unwrap()
+        .unwrap();
+
+    // Fees now sent to `fee_to` address (CHARLIE).
+    let charlie_lp_balance = psp22_utils::balance_of(&mut session, ice_wood_pair.into(), charlie());
+    // Charlie withdraws his fees
+    psp22_utils::increase_allowance(
+        &mut session,
+        ice_wood_pair.into(),
+        router.into(),
+        charlie_lp_balance,
+        CHARLIE,
+    )
+    .unwrap();
+    let (protocol_fees_ice, protocol_fees_wood) = router::remove_liquidity(
+        &mut session,
+        router.into(),
+        ice.into(),
+        wood.into(),
+        charlie_lp_balance,
+        0,
+        0,
+        charlie(),
+    );
+    // We cannot assert exactly how much fees Charlie will get, due to roundings etc,
+    // but it should be close to the expected value
+    let received_protocol_fees = protocol_fees_ice + protocol_fees_wood;
+
+    // Trading fee is 0.3%.
+    let trading_fee = (session
+        .query(ice_wood_pair.get_fee())
+        .unwrap()
+        .result
+        .unwrap() as f64)
+        / 1000.0;
+
+    // Protocol fees are 1/6 of the trading fees.
+    // Protocol fees are a sum of:
+    // * % from the input trading amount
+    // * the slippage value of the trade
+    //
+    // This makes it dynamic and hard to predict. So we're setting lower & upper bounds.
+
+    // Lower bound for the received protocol fees is the exact 0.3%/6 of the output amount.
+    let expected_protocol_fees = (swap_res[1] as f64 * trading_fee) / 6.0;
+    // Upper bound for the received protocol fees is the % from the input amount.
+    let expected_with_imp_loss = (swap_res[0] as f64 * trading_fee) / 6.0;
+
+    assert!(received_protocol_fees >= expected_protocol_fees as u128);
+    assert!(received_protocol_fees <= expected_with_imp_loss as u128);
+}
+
+#[drink::test]
+fn test_custom_fee(mut session: Session) {
+    upload_all(&mut session);
+
+    // Fix timestamp. Otherwise underlying UNIX clock is used.
+    let now = get_timestamp(&mut session);
+    set_timestamp(&mut session, now);
+
+    let fee_to_setter = bob();
+
+    // initial amount of ICE is 1_000_000_000 * 10 ** 18
+    let factory = factory::setup(&mut session, fee_to_setter);
+    let ice = psp22_utils::setup(&mut session, ICE.to_string(), BOB);
+    let wood = psp22_utils::setup(&mut session, WOOD.to_string(), BOB);
+    let wazero = wazero::setup(&mut session);
+    let router = router::setup(&mut session, factory.into(), wazero.into());
+
+    // feed Charlie some native tokens
+    session
+        .sandbox()
+        .mint_into(CHARLIE, 10u128.pow(12))
+        .unwrap();
+
+    // set fee collector to CHARLIE [3u8;32]
+    session
+        .execute(factory.set_fee_to(charlie()))
+        .unwrap()
+        .result
+        .unwrap()
+        .unwrap();
+
+    // Create new pair with custom fee
+    let small_fee: u8 = 1;
+    let ice_wood_pair: pair_contract::Instance = session
+        .instantiate(pair_contract::Instance::new(
+            ice.into(),
+            wood.into(),
+            factory.into(),
+            small_fee,
+        ))
+        .unwrap()
+        .result
+        .to_account_id()
+        .into();
+
+    // Add new pair to router cache
+    session
+        .execute(router.add_pair_to_cache(ice_wood_pair.into()))
+        .unwrap();
+
+    let amount = 1_000_000 * TOKEN;
+    psp22_utils::transfer(&mut session, ice.into(), ice_wood_pair.into(), amount, BOB).unwrap();
+    psp22_utils::transfer(&mut session, wood.into(), ice_wood_pair.into(), amount, BOB).unwrap();
+
+    let liquidity_minted = session
+        .execute(ice_wood_pair.mint(bob()))
+        .unwrap()
+        .result
+        .unwrap()
+        .unwrap();
+
+    let bob_lp_balance: u128 = psp22_utils::balance_of(&mut session, ice_wood_pair.into(), bob());
+    assert_eq!(liquidity_minted, bob_lp_balance);
+
+    let deadline = now + 10;
+
+    // Perform swap
+    let swap_amount = 10_000 * TOKEN;
+    psp22_utils::increase_allowance(&mut session, ice.into(), router.into(), swap_amount, BOB)
+        .unwrap();
     let swap_res = session
         .execute(router.swap_exact_tokens_for_tokens(
             swap_amount,
@@ -318,9 +478,8 @@ fn test_pair_cache(mut session: Session) {
     let wazero = wazero::setup(&mut session);
     let router = router::setup(&mut session, factory.into(), wazero.into());
 
-    // Create a trading pair "normal way"
-    let exp = 10u128.pow(18);
-    let token_amount = 1_000_000 * exp;
+    // Create a trading pair normal way
+    let token_amount = 1_000_000 * TOKEN;
     psp22_utils::increase_allowance(&mut session, ice.into(), router.into(), u128::MAX, BOB)
         .unwrap();
     psp22_utils::increase_allowance(&mut session, wood.into(), router.into(), u128::MAX, BOB)

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -164,6 +164,21 @@ pub mod router {
             .unwrap()
             .unwrap()
     }
+
+    pub fn get_cached_pair(
+        session: &mut Session<MinimalRuntime>,
+        router: AccountId,
+        token0: AccountId,
+        token1: AccountId,
+    ) -> AccountId {
+        session
+            .query(router_contract::Instance::from(router).read_cache(token0, token1))
+            .unwrap()
+            .result
+            .unwrap()
+            .unwrap()
+            .0
+    }
 }
 
 pub mod psp22_utils {

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -11,6 +11,8 @@ pub const WOOD: &str = "WOOD";
 pub const BOB: drink::AccountId32 = AccountId32::new([1u8; 32]);
 pub const CHARLIE: drink::AccountId32 = AccountId32::new([3u8; 32]);
 
+pub const TOKEN: u128 = 10u128.pow(18);
+
 pub fn bob() -> ink_primitives::AccountId {
     AsRef::<[u8; 32]>::as_ref(&BOB).clone().into()
 }
@@ -197,7 +199,7 @@ pub mod psp22_utils {
         let _ = session.set_actor(caller);
 
         let instance = PSP22::new(
-            1_000_000_000u128 * 10u128.pow(18),
+            1_000_000_000u128 * TOKEN,
             Some(name.clone()),
             Some(name),
             18,
@@ -224,6 +226,23 @@ pub mod psp22_utils {
         handle_ink_error(
             session
                 .execute(PSP22::increase_allowance(&token.into(), spender, amount))
+                .unwrap(),
+        )
+    }
+
+    /// Increases allowance of given token to given spender by given amount.
+    pub fn transfer(
+        session: &mut Session<MinimalRuntime>,
+        token: AccountId,
+        to: AccountId,
+        amount: u128,
+        caller: drink::AccountId32,
+    ) -> Result<(), psp22::PSP22Error> {
+        let _ = session.set_actor(caller);
+
+        handle_ink_error(
+            session
+                .execute(PSP22::transfer(&token.into(), to, amount, [].to_vec()))
                 .unwrap(),
         )
     }

--- a/amm/e2e-tests/Cargo.lock
+++ b/amm/e2e-tests/Cargo.lock
@@ -2062,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "psp22"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701aea3ff70bbecb49f4a664d25292076f13bbe5592406e2ca4bddf448c37fe0"
+checksum = "5a9bdae21c2e17b9501b2c3f8597a679cfbe2f81ec5432091bd8d4b156f66194"
 dependencies = [
  "ink",
  "parity-scale-codec",

--- a/amm/traits/Cargo.lock
+++ b/amm/traits/Cargo.lock
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "psp22"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701aea3ff70bbecb49f4a664d25292076f13bbe5592406e2ca4bddf448c37fe0"
+checksum = "5a9bdae21c2e17b9501b2c3f8597a679cfbe2f81ec5432091bd8d4b156f66194"
 dependencies = [
  "ink",
  "parity-scale-codec",

--- a/amm/traits/pair.rs
+++ b/amm/traits/pair.rs
@@ -19,7 +19,7 @@ pub trait Pair {
     /// NOTE: This does not include the tokens that were transferred to the contract
     /// as part of the _current_ transaction.
     #[ink(message)]
-    fn get_reserves(&self) -> (u128, u128, u32, u8);
+    fn get_reserves(&self) -> (u128, u128, u32);
 
     /// Returns cumulative prive of the first token.
     ///

--- a/amm/traits/pair.rs
+++ b/amm/traits/pair.rs
@@ -19,7 +19,7 @@ pub trait Pair {
     /// NOTE: This does not include the tokens that were transferred to the contract
     /// as part of the _current_ transaction.
     #[ink(message)]
-    fn get_reserves(&self) -> (u128, u128, u32);
+    fn get_reserves(&self) -> (u128, u128, u32, u8);
 
     /// Returns cumulative prive of the first token.
     ///
@@ -82,6 +82,10 @@ pub trait Pair {
     /// Returns address of the second token.
     #[ink(message)]
     fn get_token_1(&self) -> AccountId;
+
+    /// Returns protocol fee (in millis).
+    #[ink(message)]
+    fn get_fee(&self) -> u8;
 }
 
 #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]

--- a/amm/traits/router.rs
+++ b/amm/traits/router.rs
@@ -194,6 +194,7 @@ pub trait Router {
         amount_in: u128,
         reserve_0: u128,
         reserve_1: u128,
+        fee: u8,
     ) -> Result<u128, RouterError>;
 
     /// Returns amount of `A` tokens user has to supply
@@ -205,6 +206,7 @@ pub trait Router {
         amount_out: u128,
         reserve_0: u128,
         reserve_1: u128,
+        fee: u8,
     ) -> Result<u128, RouterError>;
 
     /// Returns amounts of tokens received for `amount_in`.

--- a/farm/tests/Cargo.toml
+++ b/farm/tests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dev-dependencies]
-drink = "0.8.6"
+drink = "0.8.7"
 ink-wrapper-types = { git = "https://github.com/Cardinal-Cryptography/ink-wrapper", rev = "47ba45b", default-features = false, features = [
     "drink",
 ] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.72.1"
+channel = "1.77.2"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.72.1"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
Alternative way (wrt to #98) of introducing pairs with lower fee.

Changes (same as in #98):
1. Trading fee is no longer constant 0.3%
2. Fee is stored as `u8` millis, that means possible values are 0.1%-25.5%, with 0.1% step
3. Fee is set in Pair constructor and its value cannot be changed
4. `get_reserves` returns also fee value (to avoid having to call Pair twice when calculating amounts in/out in Router)

Differences wrt #98:
- avoids creating special pairs via factory and thus minimizes changes in factory
- special pairs are created "by hand" and injected in the Router pair cache
- requires adding an owner to the Router. All owner-only methods (and corresponding errors) are not added to Router public interface (trait+RouterError)