### PR TITLE
Exclude test contracts from the workspace members.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
  "amm-helpers",
  "ink",
  "parity-scale-codec",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psp22",
  "scale-info",
 ]
 
@@ -258,7 +258,7 @@ dependencies = [
  "ink",
  "parity-scale-codec",
  "primitive-types",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psp22",
  "scale-info",
 ]
 
@@ -664,7 +664,7 @@ dependencies = [
  "ink",
  "parity-scale-codec",
  "primitive-types",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psp22",
  "scale-info",
  "sp-arithmetic",
  "traits",
@@ -747,15 +747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "psp22"
-version = "0.2.2"
-dependencies = [
- "ink",
- "parity-scale-codec",
- "scale-info",
 ]
 
 [[package]]
@@ -856,10 +847,10 @@ dependencies = [
  "amm-helpers",
  "ink",
  "parity-scale-codec",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psp22",
  "scale-info",
  "traits",
- "wrapped-azero 0.1.0",
+ "wrapped-azero",
 ]
 
 [[package]]
@@ -1176,7 +1167,7 @@ dependencies = [
  "ink_metadata",
  "parity-scale-codec",
  "primitive-types",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "psp22",
  "scale-info",
  "sp-arithmetic",
 ]
@@ -1330,17 +1321,7 @@ source = "git+https://github.com/Cardinal-Cryptography/wAZERO.git#f60d2cce0eb6d2
 dependencies = [
  "ink",
  "parity-scale-codec",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wrapped-azero"
-version = "1.0.0"
-dependencies = [
- "ink",
- "parity-scale-codec",
- "psp22 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "scale-info",
+ "psp22",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 resolver = "2"
 
-members = ["amm/contracts/*", "farm/contract", "farm/trait", "test-contracts/*"]
+members = ["amm/contracts/*", "farm/contract", "farm/trait"]
 
 exclude = [
     "amm/e2e-tests",
@@ -10,4 +10,6 @@ exclude = [
     "helpers",
     "farm/tests",
     "amm/drink-tests",
+    "test-contracts/wrapped-azero",
+    "test-contracts/psp22",
 ]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-amm: ## Builds AMM contracts.
 	@cd amm && make build-amm && cd ..
 
 .PHONY: build-all
-build-all: build-farm build-amm ## Builds all contracts.
+build-all: build-farm build-amm build-test-contracts ## Builds all contracts.
 
 .PHONY: build-test-contracts
 build-test-contracts: ## Builds contracts used in e2e-tests

--- a/amm/Makefile
+++ b/amm/Makefile
@@ -10,6 +10,11 @@ AMM_CONTRACTS_PATHS := $(shell find $(AMM_CONTRACTS) -mindepth 1 -maxdepth 1 -ty
 TEST_CONTRACTS = ../test-contracts
 TEST_PATHS := $(shell find $(TEST_CONTRACTS) -mindepth 1 -maxdepth 1 -type d)
 
+CONTRACTS := factory_contract pair_contract router_contract wrapped_azero
+
+INK_DEV_IMAGE := "public.ecr.aws/p6e8q1z1/ink-dev:2.1.0"
+SCRIPT_DIR := $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 .PHONY: build-amm
 build-amm: ## Builds AMM contracts.
 	@for d in $(AMM_CONTRACTS_PATHS); do \
@@ -30,20 +35,15 @@ check-amm: check-drink-tests ## Runs cargo (contract) check on AMM contracts.
 build-test-contracts: ## Builds contracts used in e2e-tests
 	@for d in $(TEST_PATHS); do \
 		echo "Building $$d contract" ; \
-		cargo contract build --quiet --manifest-path $$d/Cargo.toml --release --features "contract"; \
+		cd $$d && cargo contract build --quiet --release --features "contract" && cd $(SCRIPT_DIR) ; \
 	done
 
 .PHONY: build-all
 build-all: build-amm build-test-contracts ## Builds all contracts.
 
-CONTRACTS := factory_contract pair_contract router_contract wrapped_azero
-
 .PHONY: wrap-all
 wrap-all: ## Generates Rust wrappers for interacting with AMM contracts.
 	./scripts/prepare_rust_wrappers.sh
-
-INK_DEV_IMAGE := "public.ecr.aws/p6e8q1z1/ink-dev:2.1.0"
-SCRIPT_DIR := $(shell cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 .PHONY: wrap-all-dockerized
 wrap-all-dockerized: ## Generates Rust wrappers for interacting with AMM contracts using Docker.

--- a/amm/scripts/prepare_rust_wrappers.sh
+++ b/amm/scripts/prepare_rust_wrappers.sh
@@ -12,6 +12,9 @@ declare -a CONTRACTS=(
     "factory_contract" 
     "pair_contract" 
     "router_contract"
+)
+
+declare -a TEST_CONTRACTS=(
     "wrapped_azero"
     "psp22"
 )
@@ -23,6 +26,14 @@ function wrap_contracts() {
 		            --wasm-path ../resources/$c.wasm \
 	 		| rustfmt --edition 2021 > $SCRIPT_DIR/../drink-tests/src/$c.rs ;
     done
+    echo "Wrapping wrapped_azero" &&
+    ink-wrapper --metadata $SCRIPT_DIR/../../test-contracts/wrapped-azero/target/ink/wrapped_azero.json \
+                --wasm-path ../resources/wrapped_azero.wasm \
+        | rustfmt --edition 2021 > $SCRIPT_DIR/../drink-tests/src/wrapped_azero.rs ;
+    echo "Wrapping psp22" &&
+    ink-wrapper --metadata $SCRIPT_DIR/../../test-contracts/psp22/target/ink/psp22.json \
+                --wasm-path ../resources/psp22.wasm \
+        | rustfmt --edition 2021 > $SCRIPT_DIR/../drink-tests/src/psp22.rs ;
 }
 
 function copy_wasms() {
@@ -30,6 +41,10 @@ function copy_wasms() {
         echo "Copying $c.wasm"
         cp $SCRIPT_DIR/../../target/ink/$c/$c.wasm $SCRIPT_DIR/../drink-tests/resources/$c.wasm;
     done
+    echo "Copying wrapped_zero.wasm" &&
+    cp $SCRIPT_DIR/../../test-contracts/wrapped-azero/target/ink/wrapped_azero.wasm $SCRIPT_DIR/../drink-tests/resources/wrapped_azero.wasm ;
+    echo "Copying psp22.wasm" &&
+    cp $SCRIPT_DIR/../../test-contracts/psp22/target/ink/psp22.wasm $SCRIPT_DIR/../drink-tests/resources/psp22.wasm ;
 }
 
 function run() {

--- a/farm/Makefile
+++ b/farm/Makefile
@@ -28,8 +28,8 @@ generate-psp22-wrapper: ## Generates Rust wrappers for interacting with PSP22 co
 	@echo "Building PSP22 contract" ; \
 	cargo contract build --quiet --manifest-path ../test-contracts/psp22/Cargo.toml --release --features "contract" ;
 	@echo "Wrapping PSP22 contract" ; \
-	ink-wrapper --metadata ../target/ink/psp22/psp22.json \
-				--wasm-path ../../../../target/ink/psp22/psp22.wasm \
+	ink-wrapper --metadata ../test-contracts/psp22/target/ink/psp22.json \
+				--wasm-path ../../../../test-contracts/psp22/target/ink/psp22.wasm \
 		| rustfmt --edition 2021 > ./tests/src/psp22/psp22_contract.rs ; \
 
 .PHONY: generate-wrappers

--- a/farm/contract/lib.rs
+++ b/farm/contract/lib.rs
@@ -547,7 +547,7 @@ mod farm {
             .map_err(|_| MathError::CastOverflow)
     }
 
-    pub fn no_duplicates<A: Eq + PartialEq>(v: &Vec<A>) -> bool {
+    pub fn no_duplicates<A: Eq + PartialEq>(v: &[A]) -> bool {
         for (idx, el) in v.iter().enumerate() {
             // Add 1 since the first `idx=0` and we would
             // start iterating from the beginning (rather than the next element).

--- a/scripts/commonfarms-cli/commonfarms-cli
+++ b/scripts/commonfarms-cli/commonfarms-cli
@@ -33,6 +33,10 @@ def argument_parser():
     withdraw.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
     withdraw.add_argument('--token', required=True, metavar='ACCOUNT_ID', help='contract address of the token')
 
+    add_reward_token = commands.add_parser('add_reward_token', help='add a new reward token to an existing farm')
+    add_reward_token.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
+    add_reward_token.add_argument('--token', required=True, metavar='ACCOUNT_ID', help='contract address of the new reward token')
+
     return parser
 
 
@@ -112,3 +116,8 @@ if __name__ == "__main__":
     elif args.command == 'withdraw':
         check_account_ids(chain, args.farm, args.token)
         call_contract(chain, keypair, args.farm, args.metadata, method='Farm::owner_withdraw_token', token=args.token)
+    elif args.command == 'add_reward_token':
+        check_account_ids(chain, args.farm, args.token)
+        call_contract(chain, keypair, args.farm, args.metadata, method='Farm::owner_add_reward_token', token=args.token)
+    else:
+        raise ValueError(f'Unknown command: {args.command}')


### PR DESCRIPTION
Excluding test-contracts from the members speeds up compilation a bit and does not clean them with `cargo clean` - this makes sense since these contracts are not changing.

Added new subcommand to Python client for managing farms.