### PR TITLE
A0-2999: Run on workflows on node20

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -12,12 +12,12 @@ jobs:
     runs-on: [self-hosted, Linux, X64, large]
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Cache Crates
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cargo 
         key: ${{ runner.os }}-rust-${{ hashFiles('rust-toolchain.toml') }}


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.