### PR TITLE
Add Ownable to Farm

### DIFF
--- a/farm/contract/lib.rs
+++ b/farm/contract/lib.rs
@@ -5,7 +5,7 @@ mod farm {
     type TokenId = AccountId;
     type UserId = AccountId;
     use amm_helpers::{ensure, math::casted_mul, types::WrappedU256};
-    use farm_trait::{Farm, FarmDetails, FarmError};
+    use farm_trait::{Farm, FarmDetails, FarmError, Ownable};
     use ink::{codegen::EmitEvent, contract_ref, reflect::ContractEventBase, storage::Mapping};
 
     use ink::prelude::{vec, vec::Vec};
@@ -508,6 +508,21 @@ mod farm {
                 reward_tokens: self.reward_tokens.clone(),
                 reward_rates: self.reward_rates_to_u128().unwrap(),
             }
+        }
+    }
+
+    impl Ownable for FarmContract {
+        #[ink(message)]
+        fn owner(&self) -> AccountId {
+            self.owner
+        }
+
+        #[ink(message)]
+        fn set_owner(&mut self, new_owner: AccountId) -> Result<(), FarmError> {
+            ensure!(self.env().caller() == self.owner, FarmError::CallerNotOwner);
+            ensure!(!self.is_active, FarmError::FarmIsRunning);
+            self.owner = new_owner;
+            Ok(())
         }
     }
 

--- a/farm/trait/lib.rs
+++ b/farm/trait/lib.rs
@@ -133,3 +133,12 @@ pub trait Farm {
     #[ink(message)]
     fn view_farm_details(&self) -> FarmDetails;
 }
+
+#[ink::trait_definition]
+pub trait Ownable {
+    #[ink(message)]
+    fn set_owner(&mut self, new_owner: AccountId) -> Result<(), FarmError>;
+
+    #[ink(message)]
+    fn owner(&self) -> AccountId;
+}


### PR DESCRIPTION
Currently it's not possible to sign a `<contract>::new` constructor call w/ multisig. This little addition is meant to bridge a gap between "single-account" instantiation and multisig ownership. The plan is to:
1. Deploy from "normal account"
2. Move ownership to Multisig
3. Do all subsequent actions from Multisig after that.