### PR TITLE
Improve farm setup Python scripts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ target/
 
 .env
 .log
+
+# Pyenv directory
+env/

--- a/scripts/commonfarms-cli/commonfarms-cli
+++ b/scripts/commonfarms-cli/commonfarms-cli
@@ -29,7 +29,8 @@ def argument_parser():
     start.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
     start.add_argument('--start', required=True, metavar='TIMESTAMP', type=int, help='start time')
     start.add_argument('--end', required=True, metavar='TIMESTAMP', type=int, help='end time')
-    start.add_argument('--rewards', required=True, nargs='+', metavar='AMOUNT', type=int, help='Reward tokens amounts')
+    start.add_argument('--tokens', required=True, nargs='+', metavar='ACCOUNT_ID', help='contract addresses of the reward tokens')
+    start.add_argument('--rewards', required=True, nargs='+', metavar='AMOUNT', type=int, help='Reward tokens amounts. !!! NOTE !!! The amounts are "raw" numbers - i.e. do not account for token\'s decimals.')
 
     stop = commands.add_parser('stop', help='stop an existing farm')
     stop.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
@@ -102,7 +103,7 @@ def call_contract(chain, keypair, contract_address, metadata_file, method, **kwa
     else:
         error = receipt.error_message
         name, docs = error['name'], error['docs']
-        print(f'!!! Contract call failed with error {name}: {docs}')
+        raise ValueError(f'Contract call failed with error {name}: {docs}')
     return receipt
 
 
@@ -133,7 +134,11 @@ if __name__ == "__main__":
         deploy_contract(chain, keypair, args.farm_metadata, constructor='new',
                         pool_id=args.pool, reward_tokens=args.rewards)
     elif args.command == 'start':
-        check_account_ids(chain, args.farm)
+        check_account_ids(chain, args.farm, *args.tokens)
+        if len(args.tokens) != len(args.rewards):
+            raise ValueError('Number of reward tokens and rewards must be equal')
+        for (token, amount) in zip(args.tokens, args.rewards):
+            call_contract(chain, keypair, token, args.psp22_metadata, method='PSP22::increase_allowance', spender=args.farm, delta_value=amount)
         call_contract(chain, keypair, args.farm, args.farm_metadata, method='Farm::owner_start_new_farm', start=args.start, end=args.end, rewards=args.rewards)
     elif args.command == 'stop':
         check_account_ids(chain, args.farm)

--- a/scripts/commonfarms-cli/commonfarms-cli
+++ b/scripts/commonfarms-cli/commonfarms-cli
@@ -7,6 +7,8 @@ from time import time
 
 from substrateinterface import Keypair, SubstrateInterface, ContractCode, ContractInstance, ContractMetadata
 
+TESTNET_AZERO = '5EFDb7mKbougLtr5dnwd5KDfZ3wK55JPGPLiryKq4uRMPR46'
+MAINNET_AZERO = '5CtuFVgEUz13SFPVY6s2cZrnLDEkxQXc19aXrNARwEBeCXgg'
 
 def argument_parser():
     """Create command line arguments parser."""
@@ -15,12 +17,13 @@ def argument_parser():
     parser.add_argument('--phrase', metavar='SEED', help='seed phrase of the farm admin account (if not supplied, an interactive prompt will ask for it)')
     parser.add_argument('--farm-metadata', metavar='PATH', default='../../artifacts/farm_contract.json', help='path to farm contract metadata file')
     parser.add_argument('--psp22-metadata', metavar='PATH', default='../../artifacts/psp22.json', help='path to PSP22 contract metadata file')
+    parser.add_argument('--wazero-metadata', metavar='PATH', default='../../artifacts/wrapped_azero.json', help='path to wAZERO contract metadata file')
 
     commands = parser.add_subparsers(dest='command', required=True, metavar='COMMAND')
 
     create = commands.add_parser('create', help='create a new farm for given trading pool')
     create.add_argument('--pool', required=True, metavar='ACCOUNT_ID', help='contract address of the trading pool')
-    create.add_argument('--rewards', required=True, nargs='+', metavar='ACCOUNT_ID', help='contract addresses of PSP22 tokens distributed as rewards')
+    create.add_argument('--rewards', required=True, nargs='+', metavar='ACCOUNT_ID', help='contract addresses of PSP22 tokens distributed as rewards. Space separated.')
 
     details = commands.add_parser('details', help='get details of an existing farm')
     details.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
@@ -47,6 +50,10 @@ def argument_parser():
     increase_allowance.add_argument('--farm', required=True, metavar='ACCOUNT_ID', help='contract address of the farm')
     increase_allowance.add_argument('--token', required=True, metavar='ACCOUNT_ID', help='contract address of the token')
     increase_allowance.add_argument('--amount', required=True, metavar='AMOUNT', type=int, help='amount to increase allowance')
+
+    wrap_azero = commands.add_parser('wrap-azero', help='wraps native A0 into wrapped AZERO representation')
+    wrap_azero.add_argument('--address', required=False, metavar='ACCOUNT_ID', help='contract address of the wrapped A0 token')
+    wrap_azero.add_argument('--amount', required=True, metavar='AMOUNT', type=int, help='amount of A0 to wrap')
 
     return parser
 
@@ -158,5 +165,14 @@ if __name__ == "__main__":
     elif args.command == 'increase-allowance':
         check_account_ids(chain, args.farm, args.token)
         call_contract(chain, keypair, args.token, args.psp22_metadata, method='PSP22::increase_allowance', spender=args.farm, delta_value=args.amount)
+    elif args.command == 'wrap-azero':
+        if not args.address and args.chain == 'mainnet':
+            args.address = MAINNET_AZERO
+        elif not args.address and args.chain == 'testnet':
+            args.address = TESTNET_AZERO
+        else:
+            raise ValueError('Wrapped A0 contract address must be provided for wrapping')
+        check_account_ids(chain, args.address)
+        call_contract(chain, keypair, args.address, args.wazero_metadata, method='WrappedAZERO::deposit', amount=args.amount)
     else:
         raise ValueError(f'Unknown command: {args.command}')

--- a/scripts/commonfarms-cli/commonfarms-cli
+++ b/scripts/commonfarms-cli/commonfarms-cli
@@ -144,9 +144,12 @@ if __name__ == "__main__":
                         pool_id=args.pool, reward_tokens=args.rewards)
     elif args.command == 'start':
         check_account_ids(chain, args.farm, *args.tokens)
+        farm_length = args.end - args.start
         if len(args.tokens) != len(args.rewards):
             raise ValueError('Number of reward tokens and rewards must be equal')
         for (token, amount) in zip(args.tokens, args.rewards):
+            if amount > 0 and amount < farm_length:
+                raise ValueError(f'{token} reward amount ({amount}) must be greater than farm duration ({farm_length} ms). Otherwise farm will not pay rewards in that token')
             call_contract(chain, keypair, token, args.psp22_metadata, method='PSP22::increase_allowance', spender=args.farm, delta_value=amount)
         call_contract(chain, keypair, args.farm, args.farm_metadata, method='Farm::owner_start_new_farm', start=args.start, end=args.end, rewards=args.rewards)
     elif args.command == 'stop':

--- a/scripts/commonfarms-cli/commonfarms-cli
+++ b/scripts/commonfarms-cli/commonfarms-cli
@@ -128,6 +128,8 @@ if __name__ == "__main__":
     if args.phrase is None and args.command != 'details':
         args.phrase = getpass('Please enter the seed phrase: ')
         keypair = Keypair.create_from_uri(args.phrase)
+    elif args.command != 'details':
+        keypair = Keypair.create_from_uri(args.phrase)
 
     if args.command == 'create':
         check_account_ids(chain, args.pool, *args.rewards)


### PR DESCRIPTION
* Adds `wrap-azero` subcommand for easier farm setup where there's A0 as a rewards.
* Includes `increaseAllowance` as part of `start` (farm) subcommand.
* Remove the requirement for phrase when `details` subcommand is used.
* Raises exception if too few rewards are set to be paid for the farm duration.