### PR TITLE
Support swaps with stablepool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "amm-helpers"
+version = "0.2.0"
+source = "git+https://github.com/Cardinal-Cryptography/common-amm-stable-swap.git#cb8a8bd9b03dd1061a9a2a97142f07cf1b04d800"
+dependencies = [
+ "ink",
+ "ink_metadata",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-info",
+]
+
+[[package]]
 name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,19 +242,19 @@ dependencies = [
 name = "factory_contract"
 version = "0.1.0"
 dependencies = [
- "amm-helpers",
+ "amm-helpers 0.2.0",
  "ink",
  "pair_contract",
  "parity-scale-codec",
  "scale-info",
- "traits",
+ "traits 0.2.0",
 ]
 
 [[package]]
 name = "farm-trait"
 version = "0.1.0"
 dependencies = [
- "amm-helpers",
+ "amm-helpers 0.2.0",
  "ink",
  "parity-scale-codec",
  "psp22",
@@ -253,7 +265,7 @@ dependencies = [
 name = "farm_contract"
 version = "0.1.0"
 dependencies = [
- "amm-helpers",
+ "amm-helpers 0.2.0",
  "farm-trait",
  "ink",
  "parity-scale-codec",
@@ -660,14 +672,14 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 name = "pair_contract"
 version = "0.1.0"
 dependencies = [
- "amm-helpers",
+ "amm-helpers 0.2.0",
  "ink",
  "parity-scale-codec",
  "primitive-types",
  "psp22",
  "scale-info",
  "sp-arithmetic",
- "traits",
+ "traits 0.2.0",
 ]
 
 [[package]]
@@ -844,12 +856,12 @@ checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 name = "router_contract"
 version = "0.1.0"
 dependencies = [
- "amm-helpers",
+ "amm-helpers 0.2.0",
  "ink",
  "parity-scale-codec",
  "psp22",
  "scale-info",
- "traits",
+ "traits 0.2.0",
  "wrapped-azero",
 ]
 
@@ -1162,7 +1174,23 @@ dependencies = [
 name = "traits"
 version = "0.2.0"
 dependencies = [
- "amm-helpers",
+ "amm-helpers 0.2.0",
+ "ink",
+ "ink_metadata",
+ "parity-scale-codec",
+ "primitive-types",
+ "psp22",
+ "scale-info",
+ "sp-arithmetic",
+ "traits 0.2.0 (git+https://github.com/Cardinal-Cryptography/common-amm-stable-swap.git)",
+]
+
+[[package]]
+name = "traits"
+version = "0.2.0"
+source = "git+https://github.com/Cardinal-Cryptography/common-amm-stable-swap.git#cb8a8bd9b03dd1061a9a2a97142f07cf1b04d800"
+dependencies = [
+ "amm-helpers 0.2.0 (git+https://github.com/Cardinal-Cryptography/common-amm-stable-swap.git)",
  "ink",
  "ink_metadata",
  "parity-scale-codec",

--- a/amm/contracts/router/lib.rs
+++ b/amm/contracts/router/lib.rs
@@ -290,7 +290,7 @@ pub mod router {
             amounts[path.len() - 1] = amount_out;
             for i in (0..path.len() - 1).rev() {
                 let pool = self.get_pool(path[i].0, (path[i].1, path[i + 1].1))?;
-                amounts[i] = pool.get_amount_in(path[i].1, path[i + 1].1, amounts[i])?;
+                amounts[i] = pool.get_amount_in(path[i].1, path[i + 1].1, amounts[i + 1])?;
             }
 
             Ok(amounts)

--- a/amm/contracts/router/pool.rs
+++ b/amm/contracts/router/pool.rs
@@ -1,0 +1,164 @@
+use amm_helpers::{ensure, math::casted_mul};
+use ink::{
+    contract_ref,
+    env::DefaultEnvironment,
+    prelude::{vec, vec::Vec},
+    primitives::AccountId,
+};
+use traits::{MathError, Pair, RouterError, StablePool};
+
+const TRADING_FEE_DENOM: u128 = 1000;
+
+#[derive(scale::Decode, scale::Encode)]
+#[cfg_attr(
+    feature = "std",
+    derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout)
+)]
+pub enum Pool {
+    Pair((AccountId, AccountId), AccountId, u8),
+    StablePool(Vec<AccountId>, AccountId),
+}
+
+impl Pool {
+    pub fn get_amount_in(
+        &self,
+        token_in: AccountId,
+        token_out: AccountId,
+        amount_out: u128,
+    ) -> Result<u128, RouterError> {
+        match self {
+            Pool::Pair(_, _, _) => {
+                let (reserves, fee) = self.get_reserves_with_fee();
+                let reserves = if token_in < token_out {
+                    (reserves[0], reserves[1])
+                } else {
+                    (reserves[1], reserves[0])
+                };
+                ensure!(amount_out > 0, RouterError::InsufficientAmount);
+                ensure!(
+                    reserves.0 > 0 && reserves.1 > 0,
+                    RouterError::InsufficientLiquidity
+                );
+
+                let numerator = casted_mul(reserves.0, amount_out)
+                    .checked_mul(TRADING_FEE_DENOM.into())
+                    .ok_or(MathError::MulOverflow(14))?;
+
+                let denominator = casted_mul(
+                    reserves
+                        .1
+                        .checked_sub(amount_out)
+                        .ok_or(MathError::SubUnderflow(15))?,
+                    TRADING_FEE_DENOM - (fee as u128),
+                );
+
+                let amount_in: u128 = numerator
+                    .checked_div(denominator)
+                    .ok_or(MathError::DivByZero(8))?
+                    .checked_add(1.into())
+                    .ok_or(MathError::AddOverflow(3))?
+                    .try_into()
+                    .map_err(|_| MathError::CastOverflow(5))?;
+
+                Ok(amount_in)
+            }
+            Pool::StablePool(_, pool) => {
+                let mut pool_contract: contract_ref!(StablePool, DefaultEnvironment) =
+                    (*pool).into();
+                match pool_contract.get_swap_amount_in(token_in, token_out, amount_out) {
+                    Ok((amount_in, _)) => Ok(amount_in),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    }
+
+    pub fn get_amount_out(
+        &self,
+        token_in: AccountId,
+        token_out: AccountId,
+        amount_in: u128,
+    ) -> Result<u128, RouterError> {
+        match self {
+            Pool::Pair(_, _, _) => {
+                let (reserves, fee) = self.get_reserves_with_fee();
+                let reserves = if token_in < token_out {
+                    (reserves[0], reserves[1])
+                } else {
+                    (reserves[1], reserves[0])
+                };
+                ensure!(amount_in > 0, RouterError::InsufficientAmount);
+                ensure!(
+                    reserves.0 > 0 && reserves.1 > 0,
+                    RouterError::InsufficientLiquidity
+                );
+
+                // Adjusts for fees paid in the `token_in`.
+                let amount_in_with_fee = casted_mul(amount_in, TRADING_FEE_DENOM - (fee as u128));
+
+                let numerator = amount_in_with_fee
+                    .checked_mul(reserves.1.into())
+                    .ok_or(MathError::MulOverflow(13))?;
+
+                let denominator = casted_mul(reserves.0, TRADING_FEE_DENOM)
+                    .checked_add(amount_in_with_fee)
+                    .ok_or(MathError::AddOverflow(2))?;
+
+                let amount_out: u128 = numerator
+                    .checked_div(denominator)
+                    .ok_or(MathError::DivByZero(7))?
+                    .try_into()
+                    .map_err(|_| MathError::CastOverflow(4))?;
+
+                Ok(amount_out)
+            }
+            Pool::StablePool(_, pool) => {
+                let mut pool_contract: contract_ref!(StablePool, DefaultEnvironment) =
+                    (*pool).into();
+                match pool_contract.get_swap_amount_out(token_in, token_out, amount_in) {
+                    Ok((amount_out, _)) => Ok(amount_out),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    }
+
+    pub fn get_reserves_with_fee(&self) -> (Vec<u128>, u8) {
+        match self {
+            Pool::Pair(_, pool, fee) => {
+                let pair: contract_ref!(Pair, DefaultEnvironment) = (*pool).into();
+                let (reserve_0, reserve_1, _) = pair.get_reserves();
+                (vec![reserve_0, reserve_1], *fee)
+            }
+            Pool::StablePool(_, _) => unimplemented!(),
+        }
+    }
+
+    pub fn swap(
+        &self,
+        token_in: AccountId,
+        token_out: AccountId,
+        amount_out: u128,
+        to: AccountId,
+    ) -> Result<(), RouterError> {
+        ensure!(token_in != token_out, RouterError::IdenticalAddresses);
+        match self {
+            Pool::Pair(_, pair, _) => {
+                let (amount_0_out, amount_1_out) = if token_in < token_out {
+                    (0, amount_out)
+                } else {
+                    (amount_out, 0)
+                };
+
+                let mut pair_contract: contract_ref!(Pair, DefaultEnvironment) = (*pair).into();
+                pair_contract.swap(amount_0_out, amount_1_out, to, None)?
+            }
+            Pool::StablePool(_, pool) => {
+                let mut pool_contract: contract_ref!(StablePool, DefaultEnvironment) =
+                    (*pool).into();
+                pool_contract.swap_received(token_in, token_out, amount_out, to)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/amm/drink-tests/src/router_tests.rs
+++ b/amm/drink-tests/src/router_tests.rs
@@ -220,7 +220,10 @@ fn test_fees(mut session: Session) {
         .execute(router.swap_exact_tokens_for_tokens(
             swap_amount,
             0,
-            vec![ice.into(), wood.into()],
+            vec![
+                (ice_wood_pair.into(), ice.into()),
+                (ice_wood_pair.into(), wood.into()),
+            ],
             bob(),
             deadline,
         ))
@@ -381,7 +384,10 @@ fn test_custom_fee(mut session: Session) {
         .execute(router.swap_exact_tokens_for_tokens(
             swap_amount,
             0,
-            vec![ice.into(), wood.into()],
+            vec![
+                (ice_wood_pair.into(), ice.into()),
+                (ice_wood_pair.into(), wood.into()),
+            ],
             bob(),
             deadline,
         ))

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -197,7 +197,7 @@ pub mod router {
         token1: AccountId,
     ) -> AccountId {
         session
-            .query(router_contract::Instance::from(router).read_cache(token0, token1))
+            .query(router_contract::Instance::from(router).read_cached_pair(token0, token1))
             .unwrap()
             .result
             .unwrap()

--- a/amm/traits/Cargo.toml
+++ b/amm/traits/Cargo.toml
@@ -15,7 +15,10 @@ scale-info = { version = "2.9", default-features = false, features = [
     "derive",
 ], optional = true }
 
-psp22 = { version = "=0.2.2" , default-features = false }
+psp22 = { version = "=0.2.2", default-features = false }
+
+# needed to import stableswap trait for new router
+traits = { git = "https://github.com/Cardinal-Cryptography/common-amm-stable-swap.git", default-features = false }
 
 primitive-types = { version = "0.12.1", default-features = false, features = [
     "codec",
@@ -37,6 +40,7 @@ std = [
     "scale/std",
     "scale-info/std",
     "psp22/std",
+    "traits/std",
     "primitive-types/std",
     "primitive-types/scale-info",
     "sp-arithmetic/std",

--- a/amm/traits/lib.rs
+++ b/amm/traits/lib.rs
@@ -10,5 +10,6 @@ pub type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Bala
 pub use amm_helpers::math::MathError;
 pub use factory::{Factory, FactoryError};
 pub use pair::{Pair, PairError};
-pub use router::{Router, RouterError};
+pub use router::{Router, RouterError, PoolId, Step};
+pub use traits::{StablePool, StablePoolError};
 pub use swap_callee::SwapCallee;


### PR DESCRIPTION
The new `Router` contract will support swaps along paths that include `Pair` and `StablePool` types of pools.

### Swap Path
The path is a vector of `Step`s and must consist of at least 2 `Step`s. Each step is a struct `Step(PoolId, TokenId)`. The `TokenId` describes the token in of the swap for the given `PoolId`, except for the last `Step` - the last `Step` in the path always describes the token out. The `PoolId` of the last step is ignored.

E.g path `[(pool_1, token_a) , (pool_2, token_b) , (pool_x, token_c)]` can be visualized like this:
```shell
        pool_1          pool_2          pool_x - ignored
       /      \        /      \ 
token_a   ->   token_b    ->    token_c
```
### Compatibility
The old Router had a "pair caching" mechanism which allowed caching custom `Pair` contracts. Also, when adding liquidity to a non-existent pair, the pair was created through the `Factory` contract.

To keep these features, the new Router has to cache the StablePool contracts before they can be used for swaps.
When swapping, the Router checks for the pool in the following order:
1. Cached pools by `PoolId`
2. Cached pairs by `(token_in,token_out)`
3. Pairs created through Factory by `(token_in,token_out)`