### PR TITLE
Check amounts in router_v2 swap token for token test

### DIFF
--- a/amm/drink-tests/src/lib.rs
+++ b/amm/drink-tests/src/lib.rs
@@ -9,9 +9,9 @@ mod psp22;
 #[cfg(test)]
 mod router_contract;
 #[cfg(test)]
-mod router_v2_contract;
-#[cfg(test)]
 mod router_tests;
+#[cfg(test)]
+mod router_v2_contract;
 #[cfg(test)]
 mod router_v2_tests;
 #[cfg(test)]

--- a/amm/drink-tests/src/router_v2_tests.rs
+++ b/amm/drink-tests/src/router_v2_tests.rs
@@ -484,7 +484,8 @@ fn test_psp22_swap(mut session: Session) {
         ice.into(),
         usdc.into(),
         swap_amount,
-    ).unwrap();
+    )
+    .unwrap();
 
     let second_step_output = stable_swap::get_swap_amount_out(
         &mut session,
@@ -492,7 +493,8 @@ fn test_psp22_swap(mut session: Session) {
         usdc.into(),
         usdt.into(),
         first_step_output,
-    ).unwrap();
+    )
+    .unwrap();
 
     let third_step_output = v2_amounts::get_amount_out(
         &mut session,
@@ -500,7 +502,8 @@ fn test_psp22_swap(mut session: Session) {
         usdt.into(),
         wood.into(),
         second_step_output.0,
-    ).unwrap();
+    )
+    .unwrap();
 
     let init_bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
     let init_bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());
@@ -545,7 +548,8 @@ fn test_psp22_swap(mut session: Session) {
         usdt.into(),
         wood.into(),
         swap_amount,
-    ).unwrap();
+    )
+    .unwrap();
 
     let second_step_input = stable_swap::get_swap_amount_in(
         &mut session,
@@ -553,7 +557,8 @@ fn test_psp22_swap(mut session: Session) {
         usdc.into(),
         usdt.into(),
         third_step_input,
-    ).unwrap();
+    )
+    .unwrap();
 
     let first_step_input = v2_amounts::get_amount_in(
         &mut session,
@@ -561,7 +566,8 @@ fn test_psp22_swap(mut session: Session) {
         ice.into(),
         usdc.into(),
         second_step_input.0,
-    ).unwrap();
+    )
+    .unwrap();
 
     router_v2::swap_tokens_for_exact_tokens(
         &mut session,

--- a/amm/drink-tests/src/router_v2_tests.rs
+++ b/amm/drink-tests/src/router_v2_tests.rs
@@ -508,7 +508,7 @@ fn test_psp22_swap(mut session: Session) {
     let init_bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
     let init_bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());
 
-    router_v2::swap_exact_tokens_for_tokens(
+    let amounts = router_v2::swap_exact_tokens_for_tokens(
         &mut session,
         router.into(),
         swap_amount,
@@ -532,6 +532,12 @@ fn test_psp22_swap(mut session: Session) {
         BOB,
     )
     .expect("Should swap");
+
+    assert_eq!(amounts.len(), 4);
+    assert_eq!(amounts[0], swap_amount);
+    assert_eq!(amounts[1], first_step_output);
+    assert_eq!(amounts[2], second_step_output.0);
+    assert_eq!(amounts[3], third_step_output);
 
     let bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
     let bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());
@@ -569,7 +575,7 @@ fn test_psp22_swap(mut session: Session) {
     )
     .unwrap();
 
-    router_v2::swap_tokens_for_exact_tokens(
+    let amounts = router_v2::swap_tokens_for_exact_tokens(
         &mut session,
         router.into(),
         swap_amount,
@@ -593,6 +599,12 @@ fn test_psp22_swap(mut session: Session) {
         BOB,
     )
     .expect("Should swap");
+
+    assert_eq!(amounts.len(), 4);
+    assert_eq!(amounts[0], first_step_input);
+    assert_eq!(amounts[1], second_step_input.0);
+    assert_eq!(amounts[2], third_step_input);
+    assert_eq!(amounts[3], swap_amount);
 
     let bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
     let bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());

--- a/amm/drink-tests/src/router_v2_tests.rs
+++ b/amm/drink-tests/src/router_v2_tests.rs
@@ -478,6 +478,33 @@ fn test_psp22_swap(mut session: Session) {
 
     let swap_amount = 100 * TOKEN;
 
+    let first_step_output = v2_amounts::get_amount_out(
+        &mut session,
+        ice_usdc_pair.into(),
+        ice.into(),
+        usdc.into(),
+        swap_amount,
+    ).unwrap();
+
+    let second_step_output = stable_swap::get_swap_amount_out(
+        &mut session,
+        usdt_usdc_pool,
+        usdc.into(),
+        usdt.into(),
+        first_step_output,
+    ).unwrap();
+
+    let third_step_output = v2_amounts::get_amount_out(
+        &mut session,
+        wood_usdt_pair.into(),
+        usdt.into(),
+        wood.into(),
+        second_step_output.0,
+    ).unwrap();
+
+    let init_bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
+    let init_bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());
+
     router_v2::swap_exact_tokens_for_tokens(
         &mut session,
         router.into(),
@@ -503,6 +530,39 @@ fn test_psp22_swap(mut session: Session) {
     )
     .expect("Should swap");
 
+    let bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
+    let bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());
+
+    assert_eq!(init_bob_ice_balance - bob_ice_balance, swap_amount);
+    assert_eq!(bob_wood_balance - init_bob_wood_balance, third_step_output);
+
+    let init_bob_ice_balance = bob_ice_balance;
+    let init_bob_wood_balance = bob_wood_balance;
+
+    let third_step_input = v2_amounts::get_amount_in(
+        &mut session,
+        wood_usdt_pair.into(),
+        usdt.into(),
+        wood.into(),
+        swap_amount,
+    ).unwrap();
+
+    let second_step_input = stable_swap::get_swap_amount_in(
+        &mut session,
+        usdt_usdc_pool,
+        usdc.into(),
+        usdt.into(),
+        third_step_input,
+    ).unwrap();
+
+    let first_step_input = v2_amounts::get_amount_in(
+        &mut session,
+        ice_usdc_pair.into(),
+        ice.into(),
+        usdc.into(),
+        second_step_input.0,
+    ).unwrap();
+
     router_v2::swap_tokens_for_exact_tokens(
         &mut session,
         router.into(),
@@ -527,6 +587,12 @@ fn test_psp22_swap(mut session: Session) {
         BOB,
     )
     .expect("Should swap");
+
+    let bob_ice_balance = psp22_utils::balance_of(&mut session, ice.into(), bob());
+    let bob_wood_balance = psp22_utils::balance_of(&mut session, wood.into(), bob());
+
+    assert_eq!(init_bob_ice_balance - bob_ice_balance, first_step_input);
+    assert_eq!(bob_wood_balance - init_bob_wood_balance, swap_amount);
 
     for token in [usdt, usdc, ice.into(), wood.into()] {
         assert_eq!(

--- a/amm/drink-tests/src/stable_swap_tests/tests_rated.rs
+++ b/amm/drink-tests/src/stable_swap_tests/tests_rated.rs
@@ -84,7 +84,7 @@ fn setup_rated_swap_with_tokens(
 }
 
 fn set_mock_rate(session: &mut Session<MinimalRuntime>, mock_rate_contract: AccountId, rate: u128) {
-    _ = handle_ink_error(
+    let _ = handle_contract_result(
         session
             .execute(mock_rate_provider_contract::Instance::from(mock_rate_contract).set_rate(rate))
             .unwrap(),
@@ -118,7 +118,7 @@ fn test_01(mut session: Session) {
     set_timestamp(&mut session, now + 1);
     set_mock_rate(&mut session, mock_rate_provider, 2 * RATE_PRECISION);
 
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         BOB,
@@ -149,7 +149,7 @@ fn test_01(mut session: Session) {
         vec![100000 * ONE_SAZERO, 100000 * ONE_WAZERO],
         BOB,
     );
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         CHARLIE,
@@ -172,7 +172,7 @@ fn test_01(mut session: Session) {
     );
     assert_eq!(last_share_price, 100000000, "Incorrect share price");
 
-    _ = stable_swap::remove_liquidity_by_shares(
+    let _ = stable_swap::remove_liquidity_by_shares(
         &mut session,
         rated_swap.into(),
         CHARLIE,
@@ -198,7 +198,7 @@ fn test_01(mut session: Session) {
     // --- DIFF ----
     // Allow withdrawing all liquidity from the pool
 
-    _ = stable_swap::remove_liquidity_by_shares(
+    let _ = stable_swap::remove_liquidity_by_shares(
         &mut session,
         rated_swap.into(),
         BOB,
@@ -249,7 +249,7 @@ fn test_02(mut session: Session) {
     set_timestamp(&mut session, now);
     set_mock_rate(&mut session, mock_token_2_rate, 2 * RATE_PRECISION);
 
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         BOB,
@@ -284,7 +284,7 @@ fn test_02(mut session: Session) {
         ],
         BOB,
     );
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         CHARLIE,
@@ -307,7 +307,7 @@ fn test_02(mut session: Session) {
     );
     assert_eq!(last_share_price, 100000000, "Incorrect share price");
 
-    _ = stable_swap::remove_liquidity_by_shares(
+    let _ = stable_swap::remove_liquidity_by_shares(
         &mut session,
         rated_swap.into(),
         CHARLIE,
@@ -360,7 +360,7 @@ fn test_03(mut session: Session) {
     set_mock_rate(&mut session, mock_token_2_rate, 2 * RATE_PRECISION);
     set_mock_rate(&mut session, mock_token_3_rate, 4 * RATE_PRECISION);
 
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         BOB,
@@ -396,7 +396,7 @@ fn test_03(mut session: Session) {
         BOB,
     );
 
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         CHARLIE,
@@ -419,7 +419,7 @@ fn test_03(mut session: Session) {
     );
     assert_eq!(last_share_price, 100000000, "Incorrect share price");
 
-    _ = stable_swap::remove_liquidity_by_shares(
+    let _ = stable_swap::remove_liquidity_by_shares(
         &mut session,
         rated_swap.into(),
         CHARLIE,
@@ -463,7 +463,7 @@ fn test_04(mut session: Session) {
         200_000_000,
     );
 
-    _ = stable_swap::add_liquidity(
+    let _ = stable_swap::add_liquidity(
         &mut session,
         rated_swap.into(),
         BOB,
@@ -513,7 +513,7 @@ fn test_04(mut session: Session) {
         "Incorrect user token balance"
     );
 
-    _ = stable_swap::swap_exact_in(
+    let _ = stable_swap::swap_exact_in(
         &mut session,
         rated_swap.into(),
         CHARLIE,

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -219,7 +219,6 @@ pub mod router {
 
 pub mod router_v2 {
     use super::*;
-    use drink::frame_support::dispatch::PaysFee;
     use router_v2_contract::RouterV2 as _;
     use router_v2_contract::{Pool, RouterV2Error, Step};
 
@@ -670,7 +669,7 @@ pub mod psp22_utils {
     ) -> Result<(), psp22::PSP22Error> {
         let _ = session.set_actor(caller);
 
-        handle_ink_error(
+        handle_contract_result(
             session
                 .execute(PSP22::increase_allowance(&token.into(), spender, amount))
                 .unwrap(),
@@ -687,7 +686,7 @@ pub mod psp22_utils {
     ) -> Result<(), psp22::PSP22Error> {
         let _ = session.set_actor(caller);
 
-        handle_ink_error(
+        handle_contract_result(
             session
                 .execute(PSP22::transfer(&token.into(), to, amount, [].to_vec()))
                 .unwrap(),
@@ -701,7 +700,7 @@ pub mod psp22_utils {
         token: AccountId,
         account: AccountId,
     ) -> u128 {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(PSP22::balance_of(&token.into(), account))
                 .unwrap(),
@@ -709,11 +708,11 @@ pub mod psp22_utils {
     }
 
     pub fn total_supply(session: &mut Session<MinimalRuntime>, token: AccountId) -> u128 {
-        handle_ink_error(session.query(PSP22::total_supply(&token.into())).unwrap())
+        handle_contract_result(session.query(PSP22::total_supply(&token.into())).unwrap())
     }
 
     pub fn token_decimals(session: &mut Session<MinimalRuntime>, token: AccountId) -> u8 {
-        handle_ink_error(session.query(PSP22::token_decimals(&token.into())).unwrap())
+        handle_contract_result(session.query(PSP22::token_decimals(&token.into())).unwrap())
     }
 }
 
@@ -758,8 +757,8 @@ pub mod stable_swap {
         amounts: Vec<u128>,
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
-        _ = session.set_actor(caller);
-        handle_ink_error(
+        let _ = session.set_actor(caller);
+        handle_contract_result(
             session
                 .execute(
                     stable_pool_contract::Instance::from(stable_pool).add_liquidity(
@@ -780,8 +779,8 @@ pub mod stable_swap {
         amounts: Vec<u128>,
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
-        _ = session.set_actor(caller);
-        handle_ink_error(
+        let _ = session.set_actor(caller);
+        handle_contract_result(
             session
                 .execute(
                     stable_pool_contract::Instance::from(stable_pool).remove_liquidity_by_amounts(
@@ -802,8 +801,8 @@ pub mod stable_swap {
         min_amounts: Vec<u128>,
         to: AccountId,
     ) -> Result<Vec<u128>, StablePoolError> {
-        _ = session.set_actor(caller);
-        handle_ink_error(
+        let _ = session.set_actor(caller);
+        handle_contract_result(
             session
                 .execute(
                     stable_pool_contract::Instance::from(stable_pool).remove_liquidity_by_shares(
@@ -826,8 +825,8 @@ pub mod stable_swap {
         min_token_out_amount: u128,
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
-        _ = session.set_actor(caller);
-        handle_ink_error(
+        let _ = session.set_actor(caller);
+        handle_contract_result(
             session
                 .execute(
                     stable_pool_contract::Instance::from(stable_pool).swap_exact_in(
@@ -852,8 +851,8 @@ pub mod stable_swap {
         max_token_in_amount: u128,
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
-        _ = session.set_actor(caller);
-        handle_ink_error(
+        let _ = session.set_actor(caller);
+        handle_contract_result(
             session
                 .execute(
                     stable_pool_contract::Instance::from(stable_pool).swap_exact_out(
@@ -877,8 +876,8 @@ pub mod stable_swap {
         min_token_out_amount: u128,
         to: AccountId,
     ) -> Result<(u128, u128), StablePoolError> {
-        _ = session.set_actor(caller);
-        handle_ink_error(
+        let _ = session.set_actor(caller);
+        handle_contract_result(
             session
                 .execute(
                     stable_pool_contract::Instance::from(stable_pool).swap_received(
@@ -893,7 +892,7 @@ pub mod stable_swap {
     }
 
     pub fn reserves(session: &mut Session<MinimalRuntime>, stable_pool: AccountId) -> Vec<u128> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(stable_pool_contract::Instance::from(stable_pool).reserves())
                 .unwrap(),
@@ -904,7 +903,7 @@ pub mod stable_swap {
         session: &mut Session<MinimalRuntime>,
         stable_pool: AccountId,
     ) -> Result<u128, StablePoolError> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(stable_pool_contract::Instance::from(stable_pool).amp_coef())
                 .unwrap(),
@@ -912,7 +911,7 @@ pub mod stable_swap {
     }
 
     pub fn fees(session: &mut Session<MinimalRuntime>, stable_pool: AccountId) -> (u32, u32) {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(stable_pool_contract::Instance::from(stable_pool).fees())
                 .unwrap(),
@@ -920,7 +919,7 @@ pub mod stable_swap {
     }
 
     pub fn token_rates(session: &mut Session<MinimalRuntime>, stable_pool: AccountId) -> Vec<u128> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(stable_pool_contract::Instance::from(stable_pool).token_rates())
                 .unwrap(),
@@ -928,7 +927,7 @@ pub mod stable_swap {
     }
 
     pub fn tokens(session: &mut Session<MinimalRuntime>, stable_pool: AccountId) -> Vec<AccountId> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(stable_pool_contract::Instance::from(stable_pool).tokens())
                 .unwrap(),
@@ -940,7 +939,7 @@ pub mod stable_swap {
         stable_pool: AccountId,
         liquidity: u128,
     ) -> Result<Vec<u128>, StablePoolError> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(
                     stable_pool_contract::Instance::from(stable_pool)
@@ -955,7 +954,7 @@ pub mod stable_swap {
         stable_pool: AccountId,
         liquidity: u128,
     ) -> Result<Vec<u128>, StablePoolError> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(
                     stable_pool_contract::Instance::from(stable_pool)
@@ -970,7 +969,7 @@ pub mod stable_swap {
         stable_pool: AccountId,
         amounts: Vec<u128>,
     ) -> Result<(u128, u128), StablePoolError> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(
                     stable_pool_contract::Instance::from(stable_pool)
@@ -985,13 +984,41 @@ pub mod stable_swap {
         stable_pool: AccountId,
         amounts: Vec<u128>,
     ) -> Result<(u128, u128), StablePoolError> {
-        handle_ink_error(
+        handle_contract_result(
             session
                 .query(
                     stable_pool_contract::Instance::from(stable_pool)
                         .get_mint_liquidity_for_amounts(amounts),
                 )
                 .unwrap(),
+        )
+    }
+
+    fn get_swap_amount_out(
+        session: &mut Session<MinimalRuntime>,
+        stable_pool: AccountId,
+        token_in: AccountId,
+        token_out: AccountId,
+        token_in_amount: u128,
+    ) -> Result<(u128, u128), StablePoolError> {
+        handle_contract_result(
+            session.query(
+                stable_pool_contract::Instance::from(stable_pool).get_swap_amount_out(token_in, token_out, token_in_amount)
+            ).unwrap()
+        )
+    }
+
+    fn get_swap_amount_in(
+        session: &mut Session<MinimalRuntime>,
+        stable_pool: AccountId,
+        token_in: AccountId,
+        token_out: AccountId,
+        token_out_amount: u128,
+    ) -> Result<(u128, u128), StablePoolError> {
+        handle_contract_result(
+            session.query(
+                stable_pool_contract::Instance::from(stable_pool).get_swap_amount_in(token_in, token_out, token_out_amount)
+            ).unwrap()
         )
     }
 }
@@ -1004,7 +1031,7 @@ pub fn set_timestamp(session: &mut Session<MinimalRuntime>, timestamp: u64) {
     session.sandbox().set_timestamp(timestamp);
 }
 
-pub fn handle_ink_error<R>(res: ContractResult<Result<R, InkLangError>>) -> R {
+pub fn handle_contract_result<R>(res: ContractResult<Result<R, InkLangError>>) -> R {
     match res.result {
         Err(ink_lang_err) => panic!("InkLangError: {:?}", ink_lang_err),
         Ok(r) => r,

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -1004,9 +1004,15 @@ pub mod stable_swap {
         token_in_amount: u128,
     ) -> Result<(u128, u128), StablePoolError> {
         handle_contract_result(
-            session.query(
-                stable_pool_contract::Instance::from(stable_pool).get_swap_amount_out(token_in, token_out, token_in_amount)
-            ).unwrap()
+            session
+                .query(
+                    stable_pool_contract::Instance::from(stable_pool).get_swap_amount_out(
+                        token_in,
+                        token_out,
+                        token_in_amount,
+                    ),
+                )
+                .unwrap(),
         )
     }
 
@@ -1018,17 +1024,23 @@ pub mod stable_swap {
         token_out_amount: u128,
     ) -> Result<(u128, u128), StablePoolError> {
         handle_contract_result(
-            session.query(
-                stable_pool_contract::Instance::from(stable_pool).get_swap_amount_in(token_in, token_out, token_out_amount)
-            ).unwrap()
+            session
+                .query(
+                    stable_pool_contract::Instance::from(stable_pool).get_swap_amount_in(
+                        token_in,
+                        token_out,
+                        token_out_amount,
+                    ),
+                )
+                .unwrap(),
         )
     }
 }
 
 pub mod v2_amounts {
-    use primitive_types::U256;
-    use crate::pair_contract::{MathError, Pair};
     use super::*;
+    use crate::pair_contract::{MathError, Pair};
+    use primitive_types::U256;
 
     const PAIR_TRADING_FEE_DENOM: u128 = 1000;
 
@@ -1126,26 +1138,11 @@ pub mod v2_amounts {
 
     fn get_pair_params(session: &mut Session<MinimalRuntime>, pair: AccountId) -> PairParams {
         let contract = pair_contract::Instance::from(pair);
-        let token_0 = handle_contract_result(
-            session.query(
-                contract.get_token_0()
-            ).unwrap()
-        );
-        let token_1 = handle_contract_result(
-            session.query(
-                contract.get_token_1()
-            ).unwrap()
-        );
-        let (reserve_0, reserve_1, _) = handle_contract_result(
-            session.query(
-                contract.get_reserves()
-            ).unwrap()
-        );
-        let fee = handle_contract_result(
-            session.query(
-                contract.get_fee()
-            ).unwrap()
-        );
+        let token_0 = handle_contract_result(session.query(contract.get_token_0()).unwrap());
+        let token_1 = handle_contract_result(session.query(contract.get_token_1()).unwrap());
+        let (reserve_0, reserve_1, _) =
+            handle_contract_result(session.query(contract.get_reserves()).unwrap());
+        let fee = handle_contract_result(session.query(contract.get_fee()).unwrap());
 
         PairParams {
             token_0,

--- a/amm/drink-tests/src/utils.rs
+++ b/amm/drink-tests/src/utils.rs
@@ -308,6 +308,7 @@ pub mod router_v2 {
             .unwrap()
     }
 
+    #[allow(dead_code)]
     pub fn remove_pair_liquidity(
         session: &mut Session<MinimalRuntime>,
         router: AccountId,
@@ -979,6 +980,7 @@ pub mod stable_swap {
         )
     }
 
+    #[allow(dead_code)]
     pub fn get_mint_liquidity_for_amounts(
         session: &mut Session<MinimalRuntime>,
         stable_pool: AccountId,
@@ -994,7 +996,7 @@ pub mod stable_swap {
         )
     }
 
-    fn get_swap_amount_out(
+    pub fn get_swap_amount_out(
         session: &mut Session<MinimalRuntime>,
         stable_pool: AccountId,
         token_in: AccountId,
@@ -1008,7 +1010,7 @@ pub mod stable_swap {
         )
     }
 
-    fn get_swap_amount_in(
+    pub fn get_swap_amount_in(
         session: &mut Session<MinimalRuntime>,
         stable_pool: AccountId,
         token_in: AccountId,
@@ -1025,7 +1027,7 @@ pub mod stable_swap {
 
 pub mod v2_amounts {
     use primitive_types::U256;
-    use crate::pair_contract::{MathError, Pair as _,  PairError};
+    use crate::pair_contract::{MathError, Pair};
     use super::*;
 
     const PAIR_TRADING_FEE_DENOM: u128 = 1000;


### PR DESCRIPTION
## Description

Add utility functions for computing swap amounts in drink tests, and add checking amounts in `test_psp22_swap`.

## Testing

`cargo t` in `drink-tests`:

```
test result: ok. 55 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.88s
```